### PR TITLE
Prevent NPE in JWTAuthFilter and handle other token locations

### DIFF
--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -71,6 +71,24 @@
       <groupId>org.jboss.logging</groupId>
       <artifactId>jboss-logging</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.27.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.core</groupId>
+      <artifactId>jersey-common</artifactId>
+      <version>2.27</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/implementation/src/test/java/io/smallrye/jwt/auth/jaxrs/JWTAuthFilterTest.java
+++ b/implementation/src/test/java/io/smallrye/jwt/auth/jaxrs/JWTAuthFilterTest.java
@@ -1,0 +1,99 @@
+package io.smallrye.jwt.auth.jaxrs;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.Cookie;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import io.smallrye.jwt.auth.principal.JWTAuthContextInfo;
+
+public class JWTAuthFilterTest {
+
+    private static final String AUTHORIZATION = "Authorization";
+    private static final String COOKIE = "Cookie";
+
+    @Mock
+    ContainerRequestContext requestContext;
+
+    @Mock
+    JWTAuthContextInfo authContextInfo;
+
+    @InjectMocks
+    JWTAuthFilter target;
+
+    @Before
+    public void setUp() {
+        target = Mockito.spy(new JWTAuthFilter());
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testGetBearerTokenAuthorizationHeader() {
+        when(authContextInfo.getTokenHeader()).thenReturn(AUTHORIZATION);
+        when(requestContext.getHeaderString(AUTHORIZATION)).thenReturn("Bearer THE_TOKEN");
+        String bearerToken = target.getBearerToken(requestContext);
+        assertEquals("THE_TOKEN", bearerToken);
+    }
+
+    @Test
+    public void testGetBearerTokenMissingAuthorizationHeader() {
+        when(authContextInfo.getTokenHeader()).thenReturn(AUTHORIZATION);
+        when(requestContext.getHeaderString(AUTHORIZATION)).thenReturn(null);
+        String bearerToken = target.getBearerToken(requestContext);
+        assertNull(bearerToken);
+    }
+
+    @Test
+    public void testGetBearerTokenOtherSchemeAuthorizationHeader() {
+        when(authContextInfo.getTokenHeader()).thenReturn(AUTHORIZATION);
+        when(requestContext.getHeaderString(AUTHORIZATION)).thenReturn("Basic Not_a_JWT");
+        String bearerToken = target.getBearerToken(requestContext);
+        assertNull(bearerToken);
+    }
+
+    @Test
+    public void testGetBearerTokenDefaultCookieHeader() {
+        final Cookie bearerCookie = new Cookie("Bearer", "THE_TOKEN");
+        final Map<String, Cookie> cookieMap = new HashMap<>(1);
+        cookieMap.put("Bearer", bearerCookie);
+
+        when(authContextInfo.getTokenHeader()).thenReturn(COOKIE);
+        when(requestContext.getCookies()).thenReturn(cookieMap);
+        String bearerToken = target.getBearerToken(requestContext);
+        assertEquals("THE_TOKEN", bearerToken);
+    }
+
+    @Test
+    public void testGetBearerTokenCustomCookieHeader() {
+        final Cookie bearerCookie = new Cookie("CustomCookie", "THE_TOKEN");
+        final Map<String, Cookie> cookieMap = new HashMap<>(1);
+        cookieMap.put("CustomCookie", bearerCookie);
+
+        when(authContextInfo.getTokenHeader()).thenReturn(COOKIE);
+        when(authContextInfo.getTokenCookie()).thenReturn("CustomCookie");
+        when(requestContext.getCookies()).thenReturn(cookieMap);
+        String bearerToken = target.getBearerToken(requestContext);
+        assertEquals("THE_TOKEN", bearerToken);
+    }
+
+    @Test
+    public void testGetBearerTokenMissingCookieHeader() {
+        when(authContextInfo.getTokenHeader()).thenReturn(COOKIE);
+        when(requestContext.getCookies()).thenReturn(Collections.emptyMap());
+        String bearerToken = target.getBearerToken(requestContext);
+        assertNull(bearerToken);
+    }
+}


### PR DESCRIPTION
This fixes a potential `NullPointerException` situation and adds support for cookie and custom HTTP header bearer tokens to `JWTAuthFilter`. There are several test cases added here along with two `test` scope Maven dependencies to support them.

* Replace System.err.printf statements with logging and avoid printing the token to the log.
* Add test cases for JWTAuthFilter#getBearerToken and add two test dependencies (Mockito and Jersey to support tests).
