### PR TITLE
Add an error message when a public key is loaded as a resource using mp.jwt.verify.publickey.location

### DIFF
--- a/implementation/src/test/java/io/smallrye/jwt/auth/jaxrs/KeyLocationResolverTest.java
+++ b/implementation/src/test/java/io/smallrye/jwt/auth/jaxrs/KeyLocationResolverTest.java
@@ -1,0 +1,29 @@
+package io.smallrye.jwt.auth.jaxrs;
+
+import io.smallrye.jwt.auth.principal.KeyLocationResolver;
+import org.jose4j.jws.JsonWebSignature;
+import org.jose4j.lang.UnresolvableKeyException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mock;
+
+import static java.util.Collections.emptyList;
+
+public class KeyLocationResolverTest {
+
+    @Mock
+    JsonWebSignature jsonWebSignature;
+
+    @Rule
+    public ExpectedException expectedEx = ExpectedException.none();
+
+    @Test
+    public void testLoadingPublicKeyWithWrongResourceLocation() throws Exception {
+
+        expectedEx.expect(UnresolvableKeyException.class);
+
+        KeyLocationResolver keyLocationResolver = new KeyLocationResolver("wrong_location.pem");
+        keyLocationResolver.resolveKey(jsonWebSignature, emptyList());
+    }
+}


### PR DESCRIPTION
The imports order have changed because I'm using the default formatter of IntelliJ.
I can fix that if you want but I don't know the rules.