### PR TITLE
Removing the monolitic header/groups function and updating the error message

### DIFF
--- a/implementation/src/main/java/io/smallrye/jwt/config/JWTAuthContextInfoProvider.java
+++ b/implementation/src/main/java/io/smallrye/jwt/config/JWTAuthContextInfoProvider.java
@@ -182,7 +182,7 @@ public class JWTAuthContextInfoProvider {
         contextInfo.setJwksUri(mpJwtLocation.get());
         contextInfo.setFollowMpJwt11Rules(true);
     }
-    
+
     protected void decodeMpJwtPublicKey(JWTAuthContextInfo contextInfo) {
         // Need to decode what this is...
         try {
@@ -249,7 +249,7 @@ public class JWTAuthContextInfoProvider {
 
     private static Supplier<IllegalStateException> throwException() {
         final String error = "JWTAuthContextInfo has not been initialized. Please make sure that either "
-                + "public key or public key location properties are set.";
+                + "'mp.jwt.verify.publickey' or 'mp.jwt.verify.publickey.location' properties are set.";
         return () -> new IllegalStateException(error);
     }
 }

--- a/implementation/src/main/java/io/smallrye/jwt/config/JWTAuthContextInfoProvider.java
+++ b/implementation/src/main/java/io/smallrye/jwt/config/JWTAuthContextInfoProvider.java
@@ -168,16 +168,21 @@ public class JWTAuthContextInfoProvider {
         if (mpJwtLocation.isPresent() && !NONE.equals(mpJwtLocation.get())) {
             setMpJwtLocation(contextInfo);
         }
-        setTokenHeadersAndGroups(contextInfo);
+        if (tokenHeader != null) {
+            contextInfo.setTokenHeader(tokenHeader);
+        }
+        setTokenCookie(contextInfo, tokenCookie);
+        if (defaultGroupsClaim != null && defaultGroupsClaim.isPresent()) {
+            contextInfo.setDefaultGroupsClaim(defaultGroupsClaim.get());
+        }
         return Optional.of(contextInfo);
-
     }
 
     protected void setMpJwtLocation(JWTAuthContextInfo contextInfo) {
         contextInfo.setJwksUri(mpJwtLocation.get());
         contextInfo.setFollowMpJwt11Rules(true);
     }
-
+    
     protected void decodeMpJwtPublicKey(JWTAuthContextInfo contextInfo) {
         // Need to decode what this is...
         try {
@@ -198,20 +203,13 @@ public class JWTAuthContextInfoProvider {
 
     }
 
-    protected void setTokenHeadersAndGroups(JWTAuthContextInfo contextInfo) {
-        if (tokenHeader != null) {
-            contextInfo.setTokenHeader(tokenHeader);
-        }
-        if (tokenCookie != null && tokenCookie.isPresent()) {
-            if (!COOKIE_HEADER.equals(tokenHeader)) {
+    protected static void setTokenCookie(JWTAuthContextInfo contextInfo, Optional<String> cookieName) {
+        if (cookieName != null && cookieName.isPresent()) {
+            if (!COOKIE_HEADER.equals(contextInfo.getTokenHeader())) {
                 log.warn("Token header is not 'Cookie', the cookie name value will be ignored");
             } else {
-                contextInfo.setTokenCookie(tokenCookie.get());
+                contextInfo.setTokenCookie(cookieName.get());
             }
-        }
-
-        if (defaultGroupsClaim != null && defaultGroupsClaim.isPresent()) {
-            contextInfo.setDefaultGroupsClaim(defaultGroupsClaim.get());
         }
     }
 
@@ -229,6 +227,18 @@ public class JWTAuthContextInfoProvider {
 
     public Optional<Boolean> getMpJwtRequireIss() {
         return mpJwtRequireIss;
+    }
+
+    public String getTokenHeader() {
+        return tokenHeader;
+    }
+    
+    public Optional<String> getTokenCookie() {
+        return tokenCookie;
+    }
+    
+    public Optional<String> getDefaultGroupsClaim() {
+        return defaultGroupsClaim;
     }
 
     @Produces


### PR DESCRIPTION
The original function I added was a quick attempt to have it reused from Thorntail but the code for setting the cookies is not reusable. The error message in the non-optional producer method is more user friendly as well (per @starksm64 suggestion)