### PR TITLE
Support ClaimValue dynamic calls to JWT claims, add integration tests

### DIFF
--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -77,7 +77,11 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>${version.mokito}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.weld</groupId>
+      <artifactId>weld-junit4</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -103,6 +107,19 @@
           </includes>
           <forkMode>once</forkMode>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>2.22.2</version>
+        <executions>
+          <execution>
+            <id>default-integration-test</id>
+            <goals>
+              <goal>integration-test</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/implementation/src/main/java/io/smallrye/jwt/auth/cdi/ClaimValueProducer.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/cdi/ClaimValueProducer.java
@@ -17,10 +17,6 @@
 
 package io.smallrye.jwt.auth.cdi;
 
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.util.Optional;
-
 import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.Produces;
 import javax.enterprise.inject.spi.InjectionPoint;
@@ -31,8 +27,6 @@ import org.eclipse.microprofile.jwt.ClaimValue;
 
 /**
  * A producer for the ClaimValue wrapper injection sites.
- * 
- * @param <T> the raw claim type
  */
 @Dependent
 public class ClaimValueProducer {
@@ -43,40 +37,6 @@ public class ClaimValueProducer {
     @Produces
     @Claim("")
     <T> ClaimValue<T> produceClaim(InjectionPoint ip) {
-        return new ClaimValueProxy<>(ip);
-    }
-
-    private class ClaimValueProxy<T> extends ClaimValueWrapper<T> {
-        final boolean optional;
-
-        ClaimValueProxy(InjectionPoint ip) {
-            super(util.getName(ip));
-            Type injectedType = ip.getType();
-
-            if (injectedType instanceof ParameterizedType) {
-                ParameterizedType parameterizedType = (ParameterizedType) injectedType;
-                Type typeArgument = parameterizedType.getActualTypeArguments()[0];
-                // Check if the injection point is optional, i.e. ClaimValue<<Optional<?>>
-                optional = typeArgument.getTypeName().startsWith(Optional.class.getTypeName());
-            } else {
-                optional = false;
-            }
-        }
-
-        @Override
-        @SuppressWarnings("unchecked")
-        public T getValue() {
-            Object value = util.getValue(getName(), optional);
-
-            if (optional) {
-                /*
-                 * Wrap the raw value in Optional based on type parameter of the
-                 * ClaimValue checked during construction.
-                 */
-                return (T) Optional.ofNullable(value);
-            }
-
-            return (T) value;
-        }
+        return new ClaimValueWrapper<>(ip, util);
     }
 }

--- a/implementation/src/main/java/io/smallrye/jwt/auth/cdi/CommonJwtProducer.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/cdi/CommonJwtProducer.java
@@ -25,7 +25,6 @@ import javax.inject.Inject;
 import javax.json.JsonValue;
 
 import org.eclipse.microprofile.jwt.Claim;
-import org.eclipse.microprofile.jwt.ClaimValue;
 import org.eclipse.microprofile.jwt.Claims;
 import org.eclipse.microprofile.jwt.JsonWebToken;
 import org.jboss.logging.Logger;
@@ -44,22 +43,6 @@ public class CommonJwtProducer {
 
     @Inject
     JsonWebToken currentToken;
-
-    /**
-     * A utility method for accessing a claim from the current JsonWebToken as a ClaimValue Optional object.
-     *
-     * @param ip - injection point of the claim
-     * @param <T> expected actual type of the claim
-     * @return the claim value wrapper object
-     */
-    public <T> ClaimValue<Optional<T>> generalClaimValueProducer(InjectionPoint ip) {
-        String name = getName(ip);
-        ClaimValueWrapper<Optional<T>> wrapper = new ClaimValueWrapper<>(name);
-        T value = getValue(name, false);
-        Optional<T> optValue = Optional.ofNullable(value);
-        wrapper.setValue(optValue);
-        return wrapper;
-    }
 
     /**
      * Return the indicated claim value as a JsonValue

--- a/implementation/src/test/java/io/smallrye/jwt/auth/cdi/ClaimQualifier.java
+++ b/implementation/src/test/java/io/smallrye/jwt/auth/cdi/ClaimQualifier.java
@@ -1,0 +1,27 @@
+package io.smallrye.jwt.auth.cdi;
+
+import javax.enterprise.util.AnnotationLiteral;
+
+import org.eclipse.microprofile.jwt.Claim;
+import org.eclipse.microprofile.jwt.Claims;
+
+class ClaimQualifier extends AnnotationLiteral<Claim> implements Claim {
+    private static final long serialVersionUID = 1L;
+    private final String value;
+    private final Claims standard;
+
+    ClaimQualifier(String value, Claims standard) {
+        this.value = value != null ? value : "";
+        this.standard = standard != null ? standard : Claims.UNKNOWN;
+    }
+
+    @Override
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public Claims standard() {
+        return standard;
+    }
+}

--- a/implementation/src/test/java/io/smallrye/jwt/auth/cdi/ClaimValueProducerIT.java
+++ b/implementation/src/test/java/io/smallrye/jwt/auth/cdi/ClaimValueProducerIT.java
@@ -1,0 +1,110 @@
+package io.smallrye.jwt.auth.cdi;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import javax.enterprise.util.TypeLiteral;
+
+import org.eclipse.microprofile.jwt.ClaimValue;
+import org.eclipse.microprofile.jwt.Claims;
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.jboss.weld.context.bound.BoundRequestContext;
+import org.jboss.weld.junit4.WeldInitiator;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+public class ClaimValueProducerIT {
+
+    @Rule
+    public WeldInitiator weld = WeldInitiator.of(PrincipalProducer.class,
+            CommonJwtProducer.class,
+            ClaimValueProducer.class,
+            ClaimValue.class);
+
+    @Mock
+    JsonWebToken jwt;
+
+    BoundRequestContext context;
+    PrincipalProducer jwtProducer;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        context = weld.select(BoundRequestContext.class).get();
+        context.associate(new HashMap<String, Object>());
+        // Start Request Scope
+        context.activate();
+    }
+
+    @After
+    public void tearDown() {
+        // End Request Scope
+        context.deactivate();
+    }
+
+    @SuppressWarnings("unchecked")
+    <T> ClaimValue<T> selectClaimValue(String name) {
+        return weld.select(ClaimValue.class, new ClaimQualifier(name, null)).get();
+    }
+
+    @SuppressWarnings({ "serial" })
+    <T> ClaimValue<Optional<T>> selectOptionalClaimValue(String name) {
+        return weld.select(new TypeLiteral<ClaimValue<Optional<T>>>() {
+        },
+                new ClaimQualifier(name, null)).get();
+    }
+
+    @Test
+    public void testIssuerNull() {
+        ClaimValue<String> issuer = selectClaimValue("iss");
+        assertNotNull(issuer);
+        assertEquals("iss", issuer.getName());
+        assertNull(issuer.getValue());
+    }
+
+    @Test
+    public void testIssuerInjected() {
+        jwtProducer = weld.select(PrincipalProducer.class).get();
+        jwtProducer.setJsonWebToken(jwt);
+        Mockito.when(jwt.claim(Claims.iss.name())).thenReturn(Optional.of("issuer1"));
+        ClaimValue<String> issuer = selectClaimValue("iss");
+
+        assertNotNull(issuer);
+        assertEquals("iss", issuer.getName());
+        assertEquals("issuer1", issuer.getValue());
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void testOptionalIssuerNotPresent() {
+        ClaimValue<Optional<String>> issuer = selectOptionalClaimValue("iss");
+
+        assertNotNull(issuer);
+        assertEquals("iss", issuer.getName());
+        assertTrue(!issuer.getValue().isPresent());
+        issuer.getValue().get();
+    }
+
+    @Test
+    public void testOptionalIssuerInjected() {
+        jwtProducer = weld.select(PrincipalProducer.class).get();
+        jwtProducer.setJsonWebToken(jwt);
+        Mockito.when(jwt.claim(Claims.iss.name())).thenReturn(Optional.of("issuer1"));
+        ClaimValue<Optional<String>> issuer = selectOptionalClaimValue("iss");
+
+        assertNotNull(issuer);
+        assertEquals("iss", issuer.getName());
+        assertTrue(issuer.getValue().isPresent());
+        assertEquals("issuer1", issuer.getValue().get());
+    }
+}

--- a/implementation/src/test/java/io/smallrye/jwt/auth/cdi/JsonValueProducerTest.java
+++ b/implementation/src/test/java/io/smallrye/jwt/auth/cdi/JsonValueProducerTest.java
@@ -1,0 +1,73 @@
+package io.smallrye.jwt.auth.cdi;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.util.HashMap;
+import java.util.Optional;
+
+import javax.json.JsonString;
+import javax.json.JsonValue;
+
+import org.eclipse.microprofile.jwt.Claims;
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.jboss.weld.context.bound.BoundRequestContext;
+import org.jboss.weld.junit4.WeldInitiator;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+public class JsonValueProducerTest {
+
+    @Rule
+    public WeldInitiator weld = WeldInitiator.of(PrincipalProducer.class,
+            CommonJwtProducer.class,
+            JsonValueProducer.class);
+
+    @Mock
+    JsonWebToken jwt;
+
+    BoundRequestContext context;
+    PrincipalProducer jwtProducer;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        context = weld.select(BoundRequestContext.class).get();
+        context.associate(new HashMap<String, Object>());
+        // Start Request Scope
+        context.activate();
+    }
+
+    @After
+    public void tearDown() {
+        // End Request Scope
+        context.deactivate();
+    }
+
+    <T extends JsonValue> T selectJsonValue(String name, Class<T> type) {
+        return weld.select(type, new ClaimQualifier(name, null)).get();
+    }
+
+    @Test
+    public void testIssuerNullPointerException() {
+        JsonString issuer = selectJsonValue("iss", JsonString.class);
+        assertNull(issuer);
+    }
+
+    @Test
+    public void testIssuerInjected() {
+        jwtProducer = weld.select(PrincipalProducer.class).get();
+        jwtProducer.setJsonWebToken(jwt);
+        Mockito.when(jwt.claim(Claims.iss.name())).thenReturn(Optional.of("issuer1"));
+        JsonString issuer = selectJsonValue("iss", JsonString.class);
+
+        assertNotNull(issuer);
+        assertEquals("issuer1", issuer.getString());
+    }
+}

--- a/implementation/src/test/java/io/smallrye/jwt/auth/cdi/PrincipalProducerIT.java
+++ b/implementation/src/test/java/io/smallrye/jwt/auth/cdi/PrincipalProducerIT.java
@@ -1,0 +1,66 @@
+package io.smallrye.jwt.auth.cdi;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.util.Collections;
+import java.util.HashMap;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.jboss.weld.context.bound.BoundRequestContext;
+import org.jboss.weld.junit4.WeldInitiator;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+public class PrincipalProducerIT {
+
+    @Rule
+    public WeldInitiator weld = WeldInitiator.of(PrincipalProducer.class);
+
+    @Mock
+    JsonWebToken jwt;
+
+    BoundRequestContext context;
+    PrincipalProducer jwtProducer;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        context = weld.select(BoundRequestContext.class).get();
+        context.associate(new HashMap<String, Object>());
+        // Start Request Scope
+        context.activate();
+    }
+
+    @After
+    public void tearDown() {
+        // End Request Scope
+        context.deactivate();
+    }
+
+    @Test
+    public void testNullPrincipal() {
+        JsonWebToken jwt = weld.select(JsonWebToken.class).get();
+        assertNotNull(jwt);
+        assertNull(jwt.getName());
+        assertNull(jwt.getClaimNames());
+    }
+
+    @Test
+    public void testPrincipalInjected() {
+        PrincipalProducer jwtProducer = weld.select(PrincipalProducer.class).get();
+        Mockito.when(jwt.getName()).thenReturn("User1");
+        Mockito.when(jwt.getClaimNames()).thenReturn(Collections.singleton("upn"));
+        jwtProducer.setJsonWebToken(jwt);
+
+        JsonWebToken jwt = weld.select(JsonWebToken.class).get();
+        assertNotNull(jwt);
+        assertEquals("User1", jwt.getName());
+    }
+}

--- a/implementation/src/test/resources/META-INF/beans.xml
+++ b/implementation/src/test/resources/META-INF/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       bean-discovery-mode="all">
+</beans>

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
 
     <version.jose4j>0.6.5</version.jose4j>
     <version.mokito>3.0.0</version.mokito>
+    <version.weld-junit4>2.0.0.Final</version.weld-junit4>
 
     <!-- Used by release plugin to define git tag -->
     <tagNameFormat>smallrye-jwt-1.1-@{project.version}</tagNameFormat>
@@ -79,6 +80,18 @@
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-jwt-1.1</artifactId>
         <version>${project.version}</version>
+      </dependency>
+
+      <!-- Unit/Integration test dependencies -->
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>${version.mokito}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.weld</groupId>
+        <artifactId>weld-junit4</artifactId>
+        <version>${version.weld-junit4}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
This is where I am going with #113. I added some integration tests with Weld to make sure this actually works with a real CDI provider as well. The management/version for the failsafe plugin could probably be moved up into smallrye/parent sooner or later.

A few things to think about:
1. I think `CommonJwtProducer.wrapClaimValue` is no longer needed - not sure of downstream impact in Thorntail, etc. The updated code will get the claim value directly and only wrap in `Optional` if necessary versus defaulting to wrapping it and unwrapping if necessary.
2. I extended `ClaimValueWrapper`, but I believe the changes could be made directly therein if item 1 is true. I think the wrapper should _always_ delegate to the `JsonWebToken` for value lookup.

Thoughts?