### PR TITLE
Reverting to checking the scheme without URI conversion to avoid side-effects on Win

### DIFF
--- a/implementation/src/main/java/io/smallrye/jwt/auth/principal/KeyLocationResolver.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/principal/KeyLocationResolver.java
@@ -190,7 +190,7 @@ public class KeyLocationResolver implements VerificationKeyResolver {
 
     private void loadContents() throws IOException {
         final String keyLocation = authContextInfo.getPublicKeyLocation();
-        if (authContextInfo.getPublicKeyLocation().startsWith(HTTPS_SCHEME)) {
+        if (keyLocation.startsWith(HTTPS_SCHEME)) {
             httpsJwks = new HttpsJwks(keyLocation);
             httpsJwks.setDefaultCacheDuration(authContextInfo.getJwksRefreshInterval().longValue() * 60L);
             return;


### PR DESCRIPTION
The file resources are also checked first, while the URL check when neither file or classpath scheme is used is tried at the very end.
Fixes #108 