### PR TITLE
Remove ApplicationScope from getOptionalJwtAuthContextInfo

### DIFF
--- a/implementation/src/main/java/io/smallrye/jwt/config/JWTAuthContextInfoProvider.java
+++ b/implementation/src/main/java/io/smallrye/jwt/config/JWTAuthContextInfoProvider.java
@@ -227,7 +227,6 @@ public class JWTAuthContextInfoProvider {
     Optional<Set<String>> expectedAudience;
 
     @Produces
-    @ApplicationScoped
     Optional<JWTAuthContextInfo> getOptionalContextInfo() {
         // Log the config values
         log.debugf("init, mpJwtPublicKey=%s, mpJwtIssuer=%s, mpJwtLocation=%s",


### PR DESCRIPTION
Verified against the latest Thorntail and Quarkus