### PR TITLE
Cache JWTCallerPrincipalFactory within @ApplicationScoped bean.

### DIFF
--- a/implementation/src/main/java/io/smallrye/jwt/auth/AbstractBearerTokenExtractor.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/AbstractBearerTokenExtractor.java
@@ -19,7 +19,7 @@ import org.eclipse.microprofile.jwt.JsonWebToken;
 import org.jboss.logging.Logger;
 
 import io.smallrye.jwt.auth.principal.JWTAuthContextInfo;
-import io.smallrye.jwt.auth.principal.JWTCallerPrincipalFactory;
+import io.smallrye.jwt.auth.principal.JWTParser;
 import io.smallrye.jwt.auth.principal.ParseException;
 
 /**
@@ -39,9 +39,11 @@ public abstract class AbstractBearerTokenExtractor {
     private static final Logger LOGGER = Logger.getLogger(AbstractBearerTokenExtractor.class);
 
     private final JWTAuthContextInfo authContextInfo;
+    private final JWTParser jwtParser;
 
-    protected AbstractBearerTokenExtractor(JWTAuthContextInfo authContextInfo) {
+    protected AbstractBearerTokenExtractor(JWTAuthContextInfo authContextInfo, JWTParser jwtParser) {
         this.authContextInfo = authContextInfo;
+        this.jwtParser = jwtParser;
     }
 
     /**
@@ -121,8 +123,7 @@ public abstract class AbstractBearerTokenExtractor {
     }
 
     public JsonWebToken validate(String bearerToken) throws ParseException {
-        JWTCallerPrincipalFactory factory = JWTCallerPrincipalFactory.instance();
-        return factory.parse(bearerToken, authContextInfo);
+        return jwtParser.parse(bearerToken);
     }
 
     /**

--- a/implementation/src/main/java/io/smallrye/jwt/auth/AbstractBearerTokenExtractor.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/AbstractBearerTokenExtractor.java
@@ -19,8 +19,6 @@ import org.eclipse.microprofile.jwt.JsonWebToken;
 import org.jboss.logging.Logger;
 
 import io.smallrye.jwt.auth.principal.JWTAuthContextInfo;
-import io.smallrye.jwt.auth.principal.JWTParser;
-import io.smallrye.jwt.auth.principal.ParseException;
 
 /**
  * Common functionality for classes extracting Bearer tokens from HTTP request
@@ -39,11 +37,9 @@ public abstract class AbstractBearerTokenExtractor {
     private static final Logger LOGGER = Logger.getLogger(AbstractBearerTokenExtractor.class);
 
     private final JWTAuthContextInfo authContextInfo;
-    private final JWTParser jwtParser;
 
-    protected AbstractBearerTokenExtractor(JWTAuthContextInfo authContextInfo, JWTParser jwtParser) {
+    protected AbstractBearerTokenExtractor(JWTAuthContextInfo authContextInfo) {
         this.authContextInfo = authContextInfo;
-        this.jwtParser = jwtParser;
     }
 
     /**
@@ -120,10 +116,6 @@ public abstract class AbstractBearerTokenExtractor {
         String scheme = authorizationHeader.substring(0, BEARER_SCHEME_PREFIX.length());
 
         return BEARER_SCHEME_PREFIX.equalsIgnoreCase(scheme);
-    }
-
-    public JsonWebToken validate(String bearerToken) throws ParseException {
-        return jwtParser.parse(bearerToken);
     }
 
     /**

--- a/implementation/src/main/java/io/smallrye/jwt/auth/cdi/SmallRyeJWTAuthCDIExtension.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/cdi/SmallRyeJWTAuthCDIExtension.java
@@ -27,6 +27,7 @@ import org.jboss.logging.Logger;
 
 import io.smallrye.jwt.auth.jaxrs.JWTAuthenticationFilter;
 import io.smallrye.jwt.auth.mechanism.JWTHttpAuthenticationMechanism;
+import io.smallrye.jwt.auth.principal.DefaultJWTParser;
 import io.smallrye.jwt.config.JWTAuthContextInfoProvider;
 
 /**
@@ -78,6 +79,7 @@ public class SmallRyeJWTAuthCDIExtension implements Extension {
         // TODO: Do not add CDI beans unless @LoginConfig (or other trigger) is configured
         addAnnotatedType(event, beanManager, ClaimValueProducer.class);
         addAnnotatedType(event, beanManager, CommonJwtProducer.class);
+        addAnnotatedType(event, beanManager, DefaultJWTParser.class);
         addAnnotatedType(event, beanManager, JsonValueProducer.class);
         addAnnotatedType(event, beanManager, JWTAuthContextInfoProvider.class);
         addAnnotatedType(event, beanManager, JWTAuthenticationFilter.class);

--- a/implementation/src/main/java/io/smallrye/jwt/auth/jaxrs/JWTAuthenticationFilter.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/jaxrs/JWTAuthenticationFilter.java
@@ -60,12 +60,12 @@ public class JWTAuthenticationFilter implements ContainerRequestFilter {
         final Principal principal = securityContext.getUserPrincipal();
 
         if (!(principal instanceof JsonWebToken)) {
-            AbstractBearerTokenExtractor extractor = new BearerTokenExtractor(requestContext, authContextInfo, jwtParser);
+            AbstractBearerTokenExtractor extractor = new BearerTokenExtractor(requestContext, authContextInfo);
             String bearerToken = extractor.getBearerToken();
 
             if (bearerToken != null) {
                 try {
-                    JsonWebToken jwtPrincipal = extractor.validate(bearerToken);
+                    JsonWebToken jwtPrincipal = jwtParser.parse(bearerToken);
                     producer.setJsonWebToken(jwtPrincipal);
 
                     // Install the JWT principal as the caller
@@ -82,8 +82,8 @@ public class JWTAuthenticationFilter implements ContainerRequestFilter {
     private static class BearerTokenExtractor extends AbstractBearerTokenExtractor {
         private final ContainerRequestContext requestContext;
 
-        BearerTokenExtractor(ContainerRequestContext requestContext, JWTAuthContextInfo authContextInfo, JWTParser jwtParser) {
-            super(authContextInfo, jwtParser);
+        BearerTokenExtractor(ContainerRequestContext requestContext, JWTAuthContextInfo authContextInfo) {
+            super(authContextInfo);
             this.requestContext = requestContext;
         }
 

--- a/implementation/src/main/java/io/smallrye/jwt/auth/jaxrs/JWTAuthenticationFilter.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/jaxrs/JWTAuthenticationFilter.java
@@ -34,6 +34,7 @@ import org.jboss.logging.Logger;
 import io.smallrye.jwt.auth.AbstractBearerTokenExtractor;
 import io.smallrye.jwt.auth.cdi.PrincipalProducer;
 import io.smallrye.jwt.auth.principal.JWTAuthContextInfo;
+import io.smallrye.jwt.auth.principal.JWTParser;
 
 /**
  * A JAX-RS ContainerRequestFilter prototype
@@ -48,6 +49,9 @@ public class JWTAuthenticationFilter implements ContainerRequestFilter {
     private JWTAuthContextInfo authContextInfo;
 
     @Inject
+    private JWTParser jwtParser;
+
+    @Inject
     private PrincipalProducer producer;
 
     @Override
@@ -56,7 +60,7 @@ public class JWTAuthenticationFilter implements ContainerRequestFilter {
         final Principal principal = securityContext.getUserPrincipal();
 
         if (!(principal instanceof JsonWebToken)) {
-            AbstractBearerTokenExtractor extractor = new BearerTokenExtractor(requestContext, authContextInfo);
+            AbstractBearerTokenExtractor extractor = new BearerTokenExtractor(requestContext, authContextInfo, jwtParser);
             String bearerToken = extractor.getBearerToken();
 
             if (bearerToken != null) {
@@ -78,8 +82,8 @@ public class JWTAuthenticationFilter implements ContainerRequestFilter {
     private static class BearerTokenExtractor extends AbstractBearerTokenExtractor {
         private final ContainerRequestContext requestContext;
 
-        BearerTokenExtractor(ContainerRequestContext requestContext, JWTAuthContextInfo authContextInfo) {
-            super(authContextInfo);
+        BearerTokenExtractor(ContainerRequestContext requestContext, JWTAuthContextInfo authContextInfo, JWTParser jwtParser) {
+            super(authContextInfo, jwtParser);
             this.requestContext = requestContext;
         }
 

--- a/implementation/src/main/java/io/smallrye/jwt/auth/mechanism/JWTHttpAuthenticationMechanism.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/mechanism/JWTHttpAuthenticationMechanism.java
@@ -33,6 +33,7 @@ import org.jboss.logging.Logger;
 import io.smallrye.jwt.auth.AbstractBearerTokenExtractor;
 import io.smallrye.jwt.auth.cdi.PrincipalProducer;
 import io.smallrye.jwt.auth.principal.JWTAuthContextInfo;
+import io.smallrye.jwt.auth.principal.JWTParser;
 
 /**
  * A JAX-RS HttpAuthenticationMechanism prototype
@@ -47,6 +48,9 @@ public class JWTHttpAuthenticationMechanism implements HttpAuthenticationMechani
     private JWTAuthContextInfo authContextInfo;
 
     @Inject
+    private JWTParser jwtParser;
+
+    @Inject
     private PrincipalProducer producer;
 
     @Override
@@ -55,7 +59,7 @@ public class JWTHttpAuthenticationMechanism implements HttpAuthenticationMechani
             HttpMessageContext httpMessageContext)
             throws AuthenticationException {
 
-        AbstractBearerTokenExtractor extractor = new BearerTokenExtractor(request, authContextInfo);
+        AbstractBearerTokenExtractor extractor = new BearerTokenExtractor(request, authContextInfo, jwtParser);
         String bearerToken = extractor.getBearerToken();
 
         if (bearerToken != null) {
@@ -78,8 +82,8 @@ public class JWTHttpAuthenticationMechanism implements HttpAuthenticationMechani
     private static class BearerTokenExtractor extends AbstractBearerTokenExtractor {
         private final HttpServletRequest request;
 
-        BearerTokenExtractor(HttpServletRequest request, JWTAuthContextInfo authContextInfo) {
-            super(authContextInfo);
+        BearerTokenExtractor(HttpServletRequest request, JWTAuthContextInfo authContextInfo, JWTParser jwtParser) {
+            super(authContextInfo, jwtParser);
             this.request = request;
         }
 

--- a/implementation/src/main/java/io/smallrye/jwt/auth/mechanism/JWTHttpAuthenticationMechanism.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/mechanism/JWTHttpAuthenticationMechanism.java
@@ -59,12 +59,12 @@ public class JWTHttpAuthenticationMechanism implements HttpAuthenticationMechani
             HttpMessageContext httpMessageContext)
             throws AuthenticationException {
 
-        AbstractBearerTokenExtractor extractor = new BearerTokenExtractor(request, authContextInfo, jwtParser);
+        AbstractBearerTokenExtractor extractor = new BearerTokenExtractor(request, authContextInfo);
         String bearerToken = extractor.getBearerToken();
 
         if (bearerToken != null) {
             try {
-                JsonWebToken jwtPrincipal = extractor.validate(bearerToken);
+                JsonWebToken jwtPrincipal = jwtParser.parse(bearerToken);
                 producer.setJsonWebToken(jwtPrincipal);
                 Set<String> groups = jwtPrincipal.getGroups();
                 logger.debugf("Success");
@@ -82,8 +82,8 @@ public class JWTHttpAuthenticationMechanism implements HttpAuthenticationMechani
     private static class BearerTokenExtractor extends AbstractBearerTokenExtractor {
         private final HttpServletRequest request;
 
-        BearerTokenExtractor(HttpServletRequest request, JWTAuthContextInfo authContextInfo, JWTParser jwtParser) {
-            super(authContextInfo, jwtParser);
+        BearerTokenExtractor(HttpServletRequest request, JWTAuthContextInfo authContextInfo) {
+            super(authContextInfo);
             this.request = request;
         }
 

--- a/implementation/src/main/java/io/smallrye/jwt/auth/principal/DefaultJWTParser.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/principal/DefaultJWTParser.java
@@ -1,0 +1,50 @@
+/*
+ *   Copyright 2019 Red Hat, Inc, and individual contributors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package io.smallrye.jwt.auth.principal;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
+
+/**
+ * A default implementation of {@link JWTParser}.
+ */
+@ApplicationScoped
+public class DefaultJWTParser implements JWTParser {
+
+    @Inject
+    private JWTAuthContextInfo authContextInfo;
+
+    private volatile JWTCallerPrincipalFactory callerPrincipalFactory;
+
+    public JsonWebToken parse(final String bearerToken) throws ParseException {
+        return getcallerPrincipalFactory().parse(bearerToken, authContextInfo);
+    }
+
+    private JWTCallerPrincipalFactory getcallerPrincipalFactory() {
+        if (callerPrincipalFactory == null) {
+            synchronized (this) {
+                if (callerPrincipalFactory == null) {
+                    callerPrincipalFactory = JWTCallerPrincipalFactory.instance();
+                }
+            }
+        }
+        return callerPrincipalFactory;
+    }
+
+}

--- a/implementation/src/main/java/io/smallrye/jwt/auth/principal/JWTCallerPrincipalFactory.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/principal/JWTCallerPrincipalFactory.java
@@ -37,32 +37,27 @@ public abstract class JWTCallerPrincipalFactory {
      * @see #setInstance(JWTCallerPrincipalFactory)
      */
     public static JWTCallerPrincipalFactory instance() {
-        if (instance == null) {
-            synchronized (JWTCallerPrincipalFactory.class) {
-                if (instance == null) {
-
-                    ClassLoader cl = AccessController
-                            .doPrivileged((PrivilegedAction<ClassLoader>) () -> Thread.currentThread().getContextClassLoader());
-                    if (cl == null) {
-                        cl = JWTCallerPrincipalFactory.class.getClassLoader();
-                    }
-
-                    JWTCallerPrincipalFactory newInstance = loadSpi(cl);
-
-                    if (newInstance == null && cl != JWTCallerPrincipalFactory.class.getClassLoader()) {
-                        cl = JWTCallerPrincipalFactory.class.getClassLoader();
-                        newInstance = loadSpi(cl);
-                    }
-                    if (newInstance == null) {
-                        newInstance = new DefaultJWTCallerPrincipalFactory();
-                    }
-
-                    instance = newInstance;
-                }
-            }
+        if (instance != null) {
+            return instance;
         }
 
-        return instance;
+        ClassLoader cl = AccessController
+                .doPrivileged((PrivilegedAction<ClassLoader>) () -> Thread.currentThread().getContextClassLoader());
+        if (cl == null) {
+            cl = JWTCallerPrincipalFactory.class.getClassLoader();
+        }
+
+        JWTCallerPrincipalFactory newInstance = loadSpi(cl);
+
+        if (newInstance == null && cl != JWTCallerPrincipalFactory.class.getClassLoader()) {
+            cl = JWTCallerPrincipalFactory.class.getClassLoader();
+            newInstance = loadSpi(cl);
+        }
+        if (newInstance == null) {
+            newInstance = new DefaultJWTCallerPrincipalFactory();
+        }
+
+        return newInstance;
     }
 
     /**

--- a/implementation/src/main/java/io/smallrye/jwt/auth/principal/JWTParser.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/principal/JWTParser.java
@@ -1,0 +1,29 @@
+/*
+ *   Copyright 2019 Red Hat, Inc, and individual contributors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package io.smallrye.jwt.auth.principal;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
+
+/**
+ * A parser to convert from a bearer token string to a {@link JsonWebToken}.
+ */
+public interface JWTParser {
+
+    public JsonWebToken parse(final String bearerToken) throws ParseException;
+
+}

--- a/implementation/src/test/java/io/smallrye/jwt/auth/AbstractBearerTokenExtractorTest.java
+++ b/implementation/src/test/java/io/smallrye/jwt/auth/AbstractBearerTokenExtractorTest.java
@@ -28,6 +28,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import io.smallrye.jwt.auth.principal.JWTAuthContextInfo;
+import io.smallrye.jwt.auth.principal.JWTParser;
 
 public class AbstractBearerTokenExtractorTest {
 
@@ -36,6 +37,9 @@ public class AbstractBearerTokenExtractorTest {
 
     @Mock
     JWTAuthContextInfo authContextInfo;
+
+    @Mock
+    JWTParser jwtParser;
 
     AbstractBearerTokenExtractor target;
 
@@ -46,7 +50,7 @@ public class AbstractBearerTokenExtractorTest {
 
     private AbstractBearerTokenExtractor newTarget(Function<String, String> headerValue,
             Function<String, String> cookieValue) {
-        return new AbstractBearerTokenExtractor(authContextInfo) {
+        return new AbstractBearerTokenExtractor(authContextInfo, jwtParser) {
             @Override
             protected String getHeaderValue(String headerName) {
                 return headerValue.apply(headerName);

--- a/implementation/src/test/java/io/smallrye/jwt/auth/AbstractBearerTokenExtractorTest.java
+++ b/implementation/src/test/java/io/smallrye/jwt/auth/AbstractBearerTokenExtractorTest.java
@@ -28,7 +28,6 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import io.smallrye.jwt.auth.principal.JWTAuthContextInfo;
-import io.smallrye.jwt.auth.principal.JWTParser;
 
 public class AbstractBearerTokenExtractorTest {
 
@@ -37,9 +36,6 @@ public class AbstractBearerTokenExtractorTest {
 
     @Mock
     JWTAuthContextInfo authContextInfo;
-
-    @Mock
-    JWTParser jwtParser;
 
     AbstractBearerTokenExtractor target;
 
@@ -50,7 +46,7 @@ public class AbstractBearerTokenExtractorTest {
 
     private AbstractBearerTokenExtractor newTarget(Function<String, String> headerValue,
             Function<String, String> cookieValue) {
-        return new AbstractBearerTokenExtractor(authContextInfo, jwtParser) {
+        return new AbstractBearerTokenExtractor(authContextInfo) {
             @Override
             protected String getHeaderValue(String headerName) {
                 return headerValue.apply(headerName);


### PR DESCRIPTION
Integrating SmallRye components into the WildFly application server the integrated components are added to the server as a module, within WildFly each module is loaded within it's own ClassLoader which is subsequently shared across deployments.

SmallRye JWT has been making use of a static variable to cache the JWTCallerPrincipalFactory, this has a side effect of caching application specific configuration and CDI beans.  For single deployment processes or processes restarted for each redeployment the static emulates @ApplicationScoped but in WildFly it is a global scope.

This pull request is to propose moving the caching into an @ApplicationScoped bean so in all existing scenarios the behaviour should remain the same.

The existing behaviour of JWTCallerPrincipalFactory.setInstance(JWTCallerPrincipalFactory resolver); has been retained but if desirable an additional method could be added that takes Supplier<JWTCallerPrincipalFactory> which could return a new instance per application.

