### PR TITLE
Check if the resource is protected to select the appropriate response.

### DIFF
--- a/implementation/src/main/java/io/smallrye/jwt/auth/mechanism/JWTHttpAuthenticationMechanism.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/mechanism/JWTHttpAuthenticationMechanism.java
@@ -71,7 +71,8 @@ public class JWTHttpAuthenticationMechanism implements HttpAuthenticationMechani
             }
         } else {
             logger.debug("No usable bearer token was found in the request, continuing unauthenticated");
-            return httpMessageContext.doNothing();
+            return httpMessageContext.isProtected() ? httpMessageContext.responseUnauthorized()
+                    : httpMessageContext.doNothing();
         }
     }
 


### PR DESCRIPTION
The HttpMessageContext.doNothing() method results in AuthenticationStatus.NOT_DONE to be returned: -

https://javaee.github.io/javaee-spec/javadocs/javax/security/enterprise/authentication/mechanism/http/HttpMessageContext.html#doNothing--

https://javaee.github.io/javaee-spec/javadocs/javax/security/enterprise/AuthenticationStatus.html#NOT_DONE

EE Security allows for mechanisms to be called pre-emptive i.e. they are given an opportunity to authenticate if they can even if the specific resource does not require it - NOT_DONE can be returned in those cases if authentication as not attempted AND it was not required.

If however authentication is required the mechanism should instead be returning AuthenticationStatus.SEND_FAILURE to trigger a 401 to the calling client.

https://javaee.github.io/javaee-spec/javadocs/javax/security/enterprise/AuthenticationStatus.html#SEND_FAILURE
