### PR TITLE
Reduce verbosity of logging.

### DIFF
--- a/implementation/src/main/java/io/smallrye/jwt/auth/jaxrs/JWTAuthenticationFilter.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/jaxrs/JWTAuthenticationFilter.java
@@ -69,7 +69,7 @@ public class JWTAuthenticationFilter implements ContainerRequestFilter {
                     requestContext.setSecurityContext(jwtSecurityContext);
                     logger.debugf("Success");
                 } catch (Exception e) {
-                    logger.warnf(e, "Unable to parse/validate JWT: %s", e.getMessage());
+                    logger.debug("Unable to parse/validate JWT", e);
                 }
             }
         }

--- a/implementation/src/main/java/io/smallrye/jwt/auth/mechanism/JWTHttpAuthenticationMechanism.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/mechanism/JWTHttpAuthenticationMechanism.java
@@ -66,7 +66,7 @@ public class JWTHttpAuthenticationMechanism implements HttpAuthenticationMechani
                 logger.debugf("Success");
                 return httpMessageContext.notifyContainerAboutLogin(jwtPrincipal, groups);
             } catch (Exception e) {
-                logger.warnf(e, "Unable to validate bearer token: %s", e.getMessage());
+                logger.debug("Unable to validate bearer token", e);
                 return httpMessageContext.responseUnauthorized();
             }
         } else {

--- a/implementation/src/main/java/io/smallrye/jwt/auth/principal/DefaultJWTCallerPrincipal.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/principal/DefaultJWTCallerPrincipal.java
@@ -77,7 +77,7 @@ public class DefaultJWTCallerPrincipal extends JWTCallerPrincipal {
                 // Use LinkedHashSet to preserve iteration order
                 audSet = new LinkedHashSet<>(claimsSet.getAudience());
             } catch (MalformedClaimException e) {
-                LOGGER.warnf("getAudience failure: %s", e.getMessage());
+                LOGGER.debug("getAudience failure", e);
             }
         }
         return audSet;

--- a/implementation/src/main/java/io/smallrye/jwt/auth/principal/DefaultJWTTokenParser.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/principal/DefaultJWTTokenParser.java
@@ -111,7 +111,7 @@ public class DefaultJWTTokenParser {
 
             return jwtContext;
         } catch (InvalidJwtException | UnresolvableKeyException e) {
-            LOGGER.warnf("Token is invalid: %s", e.getMessage());
+            LOGGER.debug("Token is invalid");
             throw new ParseException("Failed to verify token", e);
         }
 
@@ -146,7 +146,7 @@ public class DefaultJWTTokenParser {
             if (claimValue instanceof String) {
                 return (String) claimValue;
             } else {
-                LOGGER.warnf("Claim value at the path %s is not a String", authContextInfo.getSubjectPath());
+                LOGGER.debugf("Claim value at the path %s is not a String", authContextInfo.getSubjectPath());
             }
         }
         if (authContextInfo.getDefaultSubjectClaim() != null) {
@@ -167,13 +167,13 @@ public class DefaultJWTTokenParser {
                 try {
                     return Arrays.asList(groups.toArray(new String[] {}));
                 } catch (ArrayStoreException ex) {
-                    LOGGER.warnf("Claim value at the path %s is not an array of strings",
+                    LOGGER.debugf("Claim value at the path %s is not an array of strings",
                             authContextInfo.getGroupsPath());
                 }
             } else if (claimValue instanceof String) {
                 return Arrays.asList(((String) claimValue).split(authContextInfo.getGroupsSeparator()));
             } else {
-                LOGGER.warnf("Claim value at the path %s is neither an array of strings nor string",
+                LOGGER.debugf("Claim value at the path %s is neither an array of strings nor string",
                         authContextInfo.getGroupsPath());
             }
         }
@@ -198,16 +198,16 @@ public class DefaultJWTTokenParser {
             }
             // Replace the groups with the original groups + mapped roles
             claimsSet.setStringListClaim(Claims.groups.name(), allGroups);
-            LOGGER.infof("Updated groups to: %s", allGroups);
+            LOGGER.tracef("Updated groups to: %s", allGroups);
         } catch (Exception e) {
-            LOGGER.warnf(e, "Failed to access rolesMapping claim");
+            LOGGER.debug("Failed to access rolesMapping claim", e);
         }
     }
 
     private Object findClaimValue(String claimPath, Map<String, Object> claimsMap, String[] pathArray, int step) {
         Object claimValue = claimsMap.get(pathArray[step]);
         if (claimValue == null) {
-            LOGGER.warnf("No claim exists at the path %s at segment %s", claimPath, pathArray[step]);
+            LOGGER.debugf("No claim exists at the path %s at segment %s", claimPath, pathArray[step]);
         } else if (step + 1 < pathArray.length) {
             if (claimValue instanceof Map) {
                 @SuppressWarnings("unchecked")
@@ -215,7 +215,7 @@ public class DefaultJWTTokenParser {
                 int nextStep = step + 1;
                 return findClaimValue(claimPath, nextMap, pathArray, nextStep);
             } else {
-                LOGGER.warnf("Claim value at the path %s is not a json object", claimPath);
+                LOGGER.debugf("Claim value at the path %s is not a json object", claimPath);
                 return null;
             }
         }


### PR DESCRIPTION
This pull request is a proposal to reduce the verbosity of some of the logging within SmallRye JWT.

It is common within an application server environment that the logging would be configured to log messages at INFO or higher, however it is also general desirable to avoid logging that results in per-request logging for something that is "normal operation" for the server.

For many of the messages logged although they may represent an error for a specific request they are normal operation for the server, a production server should normally expect to receive both valid and invalid tokens so provided the invalid tokens are handled correctly (i.e. rejected) it is not beneficial to log each of them to any console or log file output.

Also by logging to debug it makes it easier to log the actual exception reported, when remotely debugging an end users configuration that is not working for them it is very frustrating how often the message returned from e.getMessage() is meaningless.  By providing the option to log the full Exception at DEBUG level a lot of additional information can be obtained from an end user without too many round trips.
 