### PR TITLE
It should be possible to specify a JWK set of more than one key using the `mp.jwt.verify.publickey` config property.

### DIFF
--- a/implementation/src/main/java/io/smallrye/jwt/auth/principal/DefaultJWTTokenParser.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/principal/DefaultJWTTokenParser.java
@@ -226,7 +226,13 @@ public class DefaultJWTTokenParser {
         if (keyResolver == null) {
             synchronized (this) {
                 if (keyResolver == null)
-                    keyResolver = new KeyLocationResolver(authContextInfo);
+                    if (authContextInfo.getJsonWebKeys() != null) {
+                        LOGGER.debug("Creating key resolver for list of JWKs");
+                        keyResolver = new SimpleKeyResolver(authContextInfo.getJsonWebKeys());
+                    } else {
+                        LOGGER.debug("Creating location based key resolver");
+                        keyResolver = new KeyLocationResolver(authContextInfo);
+                    }
             }
         }
         return keyResolver;

--- a/implementation/src/main/java/io/smallrye/jwt/auth/principal/JWTAuthContextInfo.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/principal/JWTAuthContextInfo.java
@@ -20,11 +20,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import org.jose4j.jwk.JsonWebKey;
+
 /**
  * The public key and expected issuer needed to validate a token.
  */
 public class JWTAuthContextInfo {
     private RSAPublicKey signerKey;
+    private List<JsonWebKey> jsonWebKeys;
     private String issuedBy;
     private int expGracePeriodSecs = 60;
     private String publicKeyLocation;
@@ -84,6 +87,14 @@ public class JWTAuthContextInfo {
 
     public void setSignerKey(RSAPublicKey signerKey) {
         this.signerKey = signerKey;
+    }
+
+    public List<JsonWebKey> getJsonWebKeys() {
+        return jsonWebKeys;
+    }
+
+    public void setJsonWebKeys(List<JsonWebKey> jsonWebKeys) {
+        this.jsonWebKeys = jsonWebKeys;
     }
 
     public String getIssuedBy() {

--- a/implementation/src/main/java/io/smallrye/jwt/auth/principal/SimpleKeyResolver.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/principal/SimpleKeyResolver.java
@@ -1,0 +1,47 @@
+package io.smallrye.jwt.auth.principal;
+
+import java.security.Key;
+import java.util.List;
+
+import org.jboss.logging.Logger;
+import org.jose4j.jwk.JsonWebKey;
+import org.jose4j.jwk.PublicJsonWebKey;
+import org.jose4j.jws.JsonWebSignature;
+import org.jose4j.jwx.JsonWebStructure;
+import org.jose4j.keys.resolvers.VerificationKeyResolver;
+import org.jose4j.lang.UnresolvableKeyException;
+
+/**
+ * A simple VerificationKeyResolver implementation to select a Key from a list if existing JWKs.
+ */
+class SimpleKeyResolver implements VerificationKeyResolver {
+
+    private static final Logger LOGGER = Logger.getLogger(SimpleKeyResolver.class);
+
+    private final List<JsonWebKey> jsonWebKeys;
+
+    SimpleKeyResolver(List<JsonWebKey> jsonWebKeys) {
+        this.jsonWebKeys = jsonWebKeys;
+    }
+
+    @Override
+    public Key resolveKey(JsonWebSignature jws, List<JsonWebStructure> nestingContext) throws UnresolvableKeyException {
+        String kid = getKid(jws);
+
+        if (kid != null) {
+            for (JsonWebKey currentJwk : jsonWebKeys) {
+                if (kid.equals(currentJwk.getKeyId())) {
+                    return PublicJsonWebKey.class.cast(currentJwk).getPublicKey();
+                }
+            }
+        }
+
+        LOGGER.debugf("No suitable JWK for kid=%s", kid);
+        return null;
+    }
+
+    private static String getKid(JsonWebSignature jws) throws UnresolvableKeyException {
+        return jws.getHeaders().getStringHeaderValue(JsonWebKey.KEY_ID_PARAMETER);
+    }
+
+}

--- a/implementation/src/main/java/io/smallrye/jwt/config/JWTAuthContextInfoProvider.java
+++ b/implementation/src/main/java/io/smallrye/jwt/config/JWTAuthContextInfoProvider.java
@@ -17,6 +17,7 @@
 package io.smallrye.jwt.config;
 
 import java.security.interfaces.RSAPublicKey;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -29,6 +30,7 @@ import javax.inject.Inject;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
+import org.jose4j.jwk.JsonWebKey;
 
 import io.smallrye.jwt.KeyUtils;
 import io.smallrye.jwt.SmallryeJwtUtils;
@@ -289,8 +291,12 @@ public class JWTAuthContextInfoProvider {
 
         // Need to decode what this is...
         try {
-            RSAPublicKey pk = (RSAPublicKey) KeyUtils.decodeJWKSPublicKey(mpJwtPublicKey.get());
-            contextInfo.setSignerKey(pk);
+            List<JsonWebKey> jsonWebKeys = KeyUtils.decodeJsonWebKeySet(mpJwtPublicKey.get());
+            if (jsonWebKeys.size() == 1) {
+                contextInfo.setSignerKey((RSAPublicKey) jsonWebKeys.get(0).getKey());
+            } else {
+                contextInfo.setJsonWebKeys(jsonWebKeys);
+            }
             log.debugf("mpJwtPublicKey parsed as JWK(S)");
         } catch (Exception e) {
             // Try as PEM key value


### PR DESCRIPTION
Reviewing the specification there are two different config properties to specify the public key, this can either be contained within the MicroProfile Config or reference an external file.  

The specification defines a complete set of key representations that can be supported which I believe applies equally to both properties so this pull request makes it possible to handle multiple keys from a JWKS specified within the config.