### PR TITLE
Add support for custom token schemes

### DIFF
--- a/implementation/src/main/java/io/smallrye/jwt/SmallryeJwtUtils.java
+++ b/implementation/src/main/java/io/smallrye/jwt/SmallryeJwtUtils.java
@@ -97,4 +97,10 @@ public class SmallryeJwtUtils {
             }
         }
     }
+
+    public static void setTokenSchemes(JWTAuthContextInfo contextInfo, Optional<String> tokenSchemes) {
+        tokenSchemes.ifPresent(schemes -> contextInfo.setTokenSchemes(Arrays.stream(schemes.split(","))
+                .map(String::trim)
+                .collect(Collectors.toList())));
+    }
 }

--- a/implementation/src/main/java/io/smallrye/jwt/SmallryeJwtUtils.java
+++ b/implementation/src/main/java/io/smallrye/jwt/SmallryeJwtUtils.java
@@ -16,6 +16,7 @@
  */
 package io.smallrye.jwt;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -99,8 +100,12 @@ public class SmallryeJwtUtils {
     }
 
     public static void setTokenSchemes(JWTAuthContextInfo contextInfo, Optional<String> tokenSchemes) {
-        tokenSchemes.ifPresent(schemes -> contextInfo.setTokenSchemes(Arrays.stream(schemes.split(","))
-                .map(String::trim)
-                .collect(Collectors.toList())));
+        if (tokenSchemes.isPresent()) {
+            final List<String> schemes = new ArrayList<>();
+            for (final String s : tokenSchemes.get().split(",")) {
+                schemes.add(s.trim());
+            }
+            contextInfo.setTokenSchemes(schemes);
+        }
     }
 }

--- a/implementation/src/main/java/io/smallrye/jwt/auth/AbstractBearerTokenExtractor.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/AbstractBearerTokenExtractor.java
@@ -15,8 +15,6 @@
  */
 package io.smallrye.jwt.auth;
 
-import java.util.Optional;
-
 import org.eclipse.microprofile.jwt.JsonWebToken;
 import org.jboss.logging.Logger;
 
@@ -96,13 +94,9 @@ public abstract class AbstractBearerTokenExtractor {
         final String bearerValue;
 
         if (tokenHeader != null) {
-            final Optional<String> token = authContextInfo.getTokenSchemes().stream()
-                    .map(scheme -> scheme + " ")
-                    .filter(scheme -> isTokenScheme(tokenHeader, scheme))
-                    .map(scheme -> tokenHeader.substring(scheme.length()))
-                    .findFirst();
-            if (token.isPresent()) {
-                bearerValue = token.get();
+            final String token = getTokenWithConfiguredScheme(tokenHeader);
+            if (token != null) {
+                bearerValue = token;
             } else {
                 LOGGER.debugf("Authorization header does not contain a Bearer prefix");
                 bearerValue = null;
@@ -113,6 +107,16 @@ public abstract class AbstractBearerTokenExtractor {
         }
 
         return bearerValue;
+    }
+
+    private String getTokenWithConfiguredScheme(String tokenHeader) {
+        for (final String scheme : authContextInfo.getTokenSchemes()) {
+            final String schemePrefix = scheme + " ";
+            if (isTokenScheme(tokenHeader, schemePrefix)) {
+                return tokenHeader.substring(schemePrefix.length());
+            }
+        }
+        return null;
     }
 
     private static boolean isTokenScheme(String authorizationHeader, String schemePrefix) {

--- a/implementation/src/main/java/io/smallrye/jwt/auth/principal/JWTAuthContextInfo.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/principal/JWTAuthContextInfo.java
@@ -17,6 +17,7 @@ package io.smallrye.jwt.auth.principal;
 
 import java.security.interfaces.RSAPublicKey;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -32,6 +33,7 @@ public class JWTAuthContextInfo {
     private String tokenHeader = "Authorization";
     private String tokenCookie;
     private String tokenKeyId;
+    private List<String> tokenSchemes = Collections.singletonList("Bearer");
     private boolean requireNamedPrincipal = true;
     private String defaultSubClaim;
     private String subPath;
@@ -196,6 +198,14 @@ public class JWTAuthContextInfo {
 
     public void setTokenKeyId(String tokenKeyId) {
         this.tokenKeyId = tokenKeyId;
+    }
+
+    public List<String> getTokenSchemes() {
+        return tokenSchemes;
+    }
+
+    public void setTokenSchemes(final List<String> tokenSchemes) {
+        this.tokenSchemes = tokenSchemes;
     }
 
     public Set<String> getExpectedAudience() {

--- a/implementation/src/main/java/io/smallrye/jwt/config/JWTAuthContextInfoProvider.java
+++ b/implementation/src/main/java/io/smallrye/jwt/config/JWTAuthContextInfoProvider.java
@@ -41,6 +41,7 @@ import io.smallrye.jwt.auth.principal.JWTAuthContextInfo;
 @Dependent
 public class JWTAuthContextInfoProvider {
     private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_SCHEME = "BEARER";
     private static final String NONE = "NONE";
     private static final String DEFAULT_GROUPS_SEPARATOR = " ";
     private static final Logger log = Logger.getLogger(JWTAuthContextInfoProvider.class);
@@ -77,6 +78,7 @@ public class JWTAuthContextInfoProvider {
         provider.tokenHeader = AUTHORIZATION_HEADER;
         provider.tokenCookie = Optional.empty();
         provider.tokenKeyId = Optional.empty();
+        provider.tokenSchemes = Optional.of(BEARER_SCHEME);
         provider.requireNamedPrincipal = Optional.of(Boolean.TRUE);
         provider.defaultSubClaim = Optional.empty();
         provider.subPath = Optional.empty();
@@ -148,7 +150,7 @@ public class JWTAuthContextInfoProvider {
      * The scheme used with an HTTP Authorization header.
      */
     @Inject
-    @ConfigProperty(name = "smallrye.jwt.token.schemes", defaultValue = "Bearer")
+    @ConfigProperty(name = "smallrye.jwt.token.schemes", defaultValue = BEARER_SCHEME)
     private Optional<String> tokenSchemes;
 
     /**

--- a/implementation/src/main/java/io/smallrye/jwt/config/JWTAuthContextInfoProvider.java
+++ b/implementation/src/main/java/io/smallrye/jwt/config/JWTAuthContextInfoProvider.java
@@ -145,6 +145,13 @@ public class JWTAuthContextInfoProvider {
     private Optional<String> tokenKeyId;
 
     /**
+     * The scheme used with an HTTP Authorization header.
+     */
+    @Inject
+    @ConfigProperty(name = "smallrye.jwt.token.schemes", defaultValue = "Bearer")
+    private Optional<String> tokenSchemes;
+
+    /**
      * Check that the JWT has at least one of 'sub', 'upn' or 'preferred_user_name' set. If not the JWT validation will
      * fail.
      */
@@ -269,6 +276,7 @@ public class JWTAuthContextInfoProvider {
         contextInfo.setTokenKeyId(tokenKeyId.orElse(null));
         contextInfo.setRequireNamedPrincipal(requireNamedPrincipal.orElse(null));
         SmallryeJwtUtils.setContextTokenCookie(contextInfo, tokenCookie);
+        SmallryeJwtUtils.setTokenSchemes(contextInfo, tokenSchemes);
         contextInfo.setDefaultSubjectClaim(defaultSubClaim.orElse(null));
         SmallryeJwtUtils.setContextSubPath(contextInfo, subPath);
         contextInfo.setDefaultGroupsClaim(defaultGroupsClaim.orElse(null));
@@ -332,6 +340,10 @@ public class JWTAuthContextInfoProvider {
 
     public Optional<String> getTokenKeyId() {
         return tokenKeyId;
+    }
+
+    public Optional<String> getTokenSchemes() {
+        return tokenSchemes;
     }
 
     public Optional<Integer> getExpGracePeriodSecs() {

--- a/implementation/src/main/java/io/smallrye/jwt/config/JWTAuthContextInfoProvider.java
+++ b/implementation/src/main/java/io/smallrye/jwt/config/JWTAuthContextInfoProvider.java
@@ -41,7 +41,7 @@ import io.smallrye.jwt.auth.principal.JWTAuthContextInfo;
 @Dependent
 public class JWTAuthContextInfoProvider {
     private static final String AUTHORIZATION_HEADER = "Authorization";
-    private static final String BEARER_SCHEME = "BEARER";
+    private static final String BEARER_SCHEME = "Bearer";
     private static final String NONE = "NONE";
     private static final String DEFAULT_GROUPS_SEPARATOR = " ";
     private static final Logger log = Logger.getLogger(JWTAuthContextInfoProvider.class);

--- a/implementation/src/test/java/io/smallrye/jwt/auth/AbstractBearerTokenExtractorTest.java
+++ b/implementation/src/test/java/io/smallrye/jwt/auth/AbstractBearerTokenExtractorTest.java
@@ -20,6 +20,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.when;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.function.Function;
 
 import org.junit.Before;
@@ -33,6 +36,7 @@ public class AbstractBearerTokenExtractorTest {
 
     private static final String AUTHORIZATION = "Authorization";
     private static final String COOKIE = "Cookie";
+    private static final List<String> BEARER_SCHEME = Collections.singletonList("Bearer");
 
     @Mock
     JWTAuthContextInfo authContextInfo;
@@ -62,6 +66,7 @@ public class AbstractBearerTokenExtractorTest {
     @Test
     public void testGetBearerTokenAuthorizationHeader() {
         when(authContextInfo.getTokenHeader()).thenReturn(AUTHORIZATION);
+        when(authContextInfo.getTokenSchemes()).thenReturn(BEARER_SCHEME);
         AbstractBearerTokenExtractor target = newTarget(h -> "Bearer THE_TOKEN", c -> null);
         String bearerToken = target.getBearerToken();
         assertEquals("THE_TOKEN", bearerToken);
@@ -70,6 +75,7 @@ public class AbstractBearerTokenExtractorTest {
     @Test
     public void testGetBearerTokenAuthorizationHeaderMixedCase() {
         when(authContextInfo.getTokenHeader()).thenReturn(AUTHORIZATION);
+        when(authContextInfo.getTokenSchemes()).thenReturn(BEARER_SCHEME);
         AbstractBearerTokenExtractor target = newTarget(h -> "bEaReR THE_TOKEN", c -> null);
         String bearerToken = target.getBearerToken();
         assertEquals("THE_TOKEN", bearerToken);
@@ -78,6 +84,7 @@ public class AbstractBearerTokenExtractorTest {
     @Test
     public void testGetBearerTokenAuthorizationHeaderBlank() {
         when(authContextInfo.getTokenHeader()).thenReturn(AUTHORIZATION);
+        when(authContextInfo.getTokenSchemes()).thenReturn(BEARER_SCHEME);
         AbstractBearerTokenExtractor target = newTarget(h -> "BEARER ", c -> null);
         String bearerToken = target.getBearerToken();
         assertEquals("", bearerToken);
@@ -86,6 +93,7 @@ public class AbstractBearerTokenExtractorTest {
     @Test
     public void testGetBearerTokenAuthorizationHeaderInvalidSchemePrefix() {
         when(authContextInfo.getTokenHeader()).thenReturn(AUTHORIZATION);
+        when(authContextInfo.getTokenSchemes()).thenReturn(BEARER_SCHEME);
         AbstractBearerTokenExtractor target = newTarget(h -> "BEARER", c -> null);
         String bearerToken = target.getBearerToken();
         assertNull(bearerToken);
@@ -94,6 +102,7 @@ public class AbstractBearerTokenExtractorTest {
     @Test
     public void testGetBearerTokenMissingAuthorizationHeader() {
         when(authContextInfo.getTokenHeader()).thenReturn(AUTHORIZATION);
+        when(authContextInfo.getTokenSchemes()).thenReturn(BEARER_SCHEME);
         AbstractBearerTokenExtractor target = newTarget(h -> null, c -> null);
         String bearerToken = target.getBearerToken();
         assertNull(bearerToken);
@@ -102,9 +111,19 @@ public class AbstractBearerTokenExtractorTest {
     @Test
     public void testGetBearerTokenOtherSchemeAuthorizationHeader() {
         when(authContextInfo.getTokenHeader()).thenReturn(AUTHORIZATION);
+        when(authContextInfo.getTokenSchemes()).thenReturn(BEARER_SCHEME);
         AbstractBearerTokenExtractor target = newTarget(h -> "Basic Not_a_JWT", c -> null);
         String bearerToken = target.getBearerToken();
         assertNull(bearerToken);
+    }
+
+    @Test
+    public void testGetBearerTokenCustomSchemeAuthorizationHeader() {
+        when(authContextInfo.getTokenHeader()).thenReturn(AUTHORIZATION);
+        when(authContextInfo.getTokenSchemes()).thenReturn(Arrays.asList("Bearer", "DPoP"));
+        AbstractBearerTokenExtractor target = newTarget(h -> "DPoP THE_TOKEN", c -> null);
+        String bearerToken = target.getBearerToken();
+        assertEquals("THE_TOKEN", bearerToken);
     }
 
     @Test


### PR DESCRIPTION
Add a `smallrye.jwt.token.schemes` configuration value to support additional token schemes, such as DPoP.