### PR TITLE
Migrate to Jakarta EE dependencies

### DIFF
--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -31,15 +31,36 @@
 
   <dependencies>
     <dependency>
-      <groupId>javax.enterprise</groupId>
-      <artifactId>cdi-api</artifactId>
+      <groupId>jakarta.enterprise</groupId>
+      <artifactId>jakarta.enterprise.cdi-api</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>javax</groupId>
-      <artifactId>javaee-api</artifactId>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.ws.rs</groupId>
+      <artifactId>jakarta.ws.rs-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.json</groupId>
+      <artifactId>jakarta.json-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.security.enterprise</groupId>
+      <artifactId>jakarta.security.enterprise-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.eclipse.microprofile.config</groupId>
       <artifactId>microprofile-config-api</artifactId>
@@ -61,10 +82,6 @@
     </dependency>
 
     <dependency>
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.jboss.logging</groupId>
       <artifactId>jboss-logging</artifactId>
     </dependency>
@@ -83,10 +100,16 @@
       <groupId>org.jboss.weld</groupId>
       <artifactId>weld-junit4</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.enterprise</groupId>
+          <artifactId>cdi-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.json</artifactId>
+      <artifactId>jakarta.json</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.smallrye</groupId>
     <artifactId>smallrye-parent</artifactId>
-    <version>12</version>
+    <version>15</version>
   </parent>
 
   <artifactId>smallrye-jwt-parent</artifactId>
@@ -33,9 +33,12 @@
   <url>http://smallrye.io</url>
 
   <properties>
+    <version.jakarta.servlet.api>4.0.3</version.jakarta.servlet.api>
+    <version.jakarta.security.enterprise.api>1.0.2</version.jakarta.security.enterprise.api>
     <version.eclipse.microprofile.jwt>1.1.1</version.eclipse.microprofile.jwt>
     <version.microprofile.config>1.3</version.microprofile.config>
-    <version.io.smallrye.config>1.5.1</version.io.smallrye.config> 
+    <version.io.smallrye.config>1.5.1</version.io.smallrye.config>
+    <version.org.glassfish.jakarta.json>1.1.6</version.org.glassfish.jakarta.json>
     <version.jose4j>0.7.0</version.jose4j>
     <version.mokito>3.2.4</version.mokito>
     <version.weld-junit4>2.0.1.Final</version.weld-junit4>
@@ -69,6 +72,16 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>jakarta.servlet</groupId>
+        <artifactId>jakarta.servlet-api</artifactId>
+        <version>${version.jakarta.servlet.api}</version>
+      </dependency>
+      <dependency>
+        <groupId>jakarta.security.enterprise</groupId>
+        <artifactId>jakarta.security.enterprise-api</artifactId>
+        <version>${version.jakarta.security.enterprise.api}</version>
+      </dependency>
       <dependency>
         <groupId>org.eclipse.microprofile.jwt</groupId>
         <artifactId>microprofile-jwt-auth-api</artifactId>
@@ -114,6 +127,12 @@
         <groupId>io.smallrye.config</groupId>
         <artifactId>smallrye-config</artifactId>
         <version>${version.io.smallrye.config}</version>
+      </dependency>
+      <dependency>
+        <!-- Remove when updated in smallrye-parent -->
+        <groupId>org.glassfish</groupId>
+        <artifactId>jakarta.json</artifactId>
+        <version>${version.org.glassfish.jakarta.json}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/testsuite/basic/pom.xml
+++ b/testsuite/basic/pom.xml
@@ -40,11 +40,24 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>jakarta.enterprise</groupId>
+      <artifactId>jakarta.enterprise.cdi-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <!-- This is the MP-JWT TCK base extension and utility classes -->
     <dependency>
       <groupId>org.eclipse.microprofile.jwt</groupId>
       <artifactId>microprofile-jwt-auth-tck</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.inject</groupId>
+          <artifactId>javax.inject</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
    <dependency>
       <groupId>org.eclipse.microprofile.jwt</groupId>
@@ -54,7 +67,7 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.json</artifactId>
+      <artifactId>jakarta.json</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Fixes #168 

Note that the umbrella `javaee-api` dependency has been replaced with the specific APIs that are directly used. This should make it more transparent what is used. This also includes and supersedes #151 .