### PR TITLE
Add sign/innerSign/encrypt methods accepting a key location, checking  RSA key size, better docs

### DIFF
--- a/implementation/src/main/java/io/smallrye/jwt/algorithm/ContentEncryptionAlgorithm.java
+++ b/implementation/src/main/java/io/smallrye/jwt/algorithm/ContentEncryptionAlgorithm.java
@@ -7,7 +7,8 @@ package io.smallrye.jwt.algorithm;
  */
 public enum ContentEncryptionAlgorithm {
     A256GCM("A256GCM"),
-    A128CBC_HS256("A128CBC-HS256");
+    A128CBC_HS256("A128CBC-HS256"),
+    A256CBC_HS512("A256CBC-HS512");
 
     private String algorithmName;
 

--- a/implementation/src/main/java/io/smallrye/jwt/algorithm/KeyEncryptionAlgorithm.java
+++ b/implementation/src/main/java/io/smallrye/jwt/algorithm/KeyEncryptionAlgorithm.java
@@ -6,7 +6,9 @@ package io.smallrye.jwt.algorithm;
  * @see <a href="https://tools.ietf.org/html/rfc7518#section-4">https://tools.ietf.org/html/rfc7518#section-4</a>
  */
 public enum KeyEncryptionAlgorithm {
+    RSA_OAEP("RSA-OAEP"),
     RSA_OAEP_256("RSA-OAEP-256"),
+    ECDH_ES("ECDH-ES"),
     ECDH_ES_A256KW("ECDH-ES+A256KW"),
     A256KW("A256KW");
 

--- a/implementation/src/main/java/io/smallrye/jwt/algorithm/SignatureAlgorithm.java
+++ b/implementation/src/main/java/io/smallrye/jwt/algorithm/SignatureAlgorithm.java
@@ -7,8 +7,14 @@ package io.smallrye.jwt.algorithm;
  */
 public enum SignatureAlgorithm {
     RS256,
+    RS384,
+    RS512,
     ES256,
-    HS256;
+    ES384,
+    ES512,
+    HS256,
+    HS384,
+    HS512;
 
     public String getAlgorithm() {
         return this.name();

--- a/implementation/src/main/java/io/smallrye/jwt/build/JwtEncryption.java
+++ b/implementation/src/main/java/io/smallrye/jwt/build/JwtEncryption.java
@@ -5,13 +5,16 @@ import java.security.PublicKey;
 import javax.crypto.SecretKey;
 
 /**
- * JWT JsonWebEncryption
+ * JWT JsonWebEncryption.
  */
 public interface JwtEncryption {
 
     /**
-     * Encrypt the claims or inner JWT with {@link PublicKey}
-     * 
+     * Encrypt the claims or inner JWT with {@link PublicKey}.
+     * 'RSA-OAEP-256' key and 'A256GCM' content encryption algorithms will be used
+     * unless different ones have been set with {@code JwtEncryptionBuilder}.
+     * A key of size 2048 bits or larger MUST be used with the 'RSA-OAEP' and 'RSA-OAEP-256' algorithms.
+     *
      * @param keyEncryptionKey the key which encrypts the content encryption key
      * @return encrypted JWT token
      * @throws JwtEncryptionException the exception if the encryption operation has failed
@@ -19,8 +22,11 @@ public interface JwtEncryption {
     String encrypt(PublicKey keyEncryptionKey) throws JwtEncryptionException;
 
     /**
-     * Encrypt the claims or inner JWT with {@link SecretKey}
-     * 
+     * Encrypt the claims or inner JWT with {@link SecretKey}.
+     * 'RSA-OAEP-256' key and 'A256GCM' content encryption algorithms will be used
+     * unless different ones have been set with {@code JwtEncryptionBuilder}.
+     * A key of size 2048 bits or larger MUST be used with the 'RSA-OAEP' and 'RSA-OAEP-256' algorithms.
+     *
      * @param keyEncryptionKey the key which encrypts the content encryption key
      * @return encrypted JWT token
      * @throws JwtEncryptionException the exception if the encryption operation has failed
@@ -28,9 +34,25 @@ public interface JwtEncryption {
     String encrypt(SecretKey keyEncryptionKey) throws JwtEncryptionException;
 
     /**
+     * Encrypt the claims or inner JWT with a public or secret key loaded from the custom location
+     * which can point to a PEM, JWK or JWK set keys.
+     * 'RSA-OAEP-256' key and 'A256GCM' content encryption algorithms will be used
+     * unless different ones have been set with {@code JwtEncryptionBuilder}.
+     * A key of size 2048 bits or larger MUST be used with the 'RSA-OAEP' and 'RSA-OAEP-256' algorithms.
+     *
+     * @param keyLocation the location of the keyEncryptionKey which encrypts the content encryption key
+     * @return encrypted JWT token
+     * @throws JwtEncryptionException the exception if the encryption operation has failed
+     */
+    String encrypt(String keyLocation) throws JwtEncryptionException;
+
+    /**
      * Encrypt the claims or inner JWT with a key loaded from the location set with the
      * "smallrye.jwt.encrypt.key-location" property.
-     * 
+     * 'RSA-OAEP-256' key and 'A256GCM' content encryption algorithms will be used
+     * unless different ones have been set with {@code JwtEncryptionBuilder}.
+     * A key of size 2048 bits or larger MUST be used with the 'RSA-OAEP' and 'RSA-OAEP-256' algorithms.
+     *
      * @return signed JWT token
      * @throws JwtSignatureException the exception if the signing operation has failed
      */

--- a/implementation/src/main/java/io/smallrye/jwt/build/JwtEncryptionBuilder.java
+++ b/implementation/src/main/java/io/smallrye/jwt/build/JwtEncryptionBuilder.java
@@ -18,7 +18,9 @@ import io.smallrye.jwt.algorithm.KeyEncryptionAlgorithm;
 public interface JwtEncryptionBuilder extends JwtEncryption {
 
     /**
-     * Set an 'alg' key encryption algorithm
+     * Set an 'alg' key encryption algorithm.
+     * Note that only 'RSA-OAEP-256' (default), 'ECDH-ES+A256KW' and 'A256KW' algorithms must be supported.
+     * A key of size 2048 bits or larger MUST be used with 'RSA-OAEP-256' algorithm.
      * 
      * @param algorithm the key encryption algorithm
      * @return JwtEncryptionBuilder
@@ -26,7 +28,8 @@ public interface JwtEncryptionBuilder extends JwtEncryption {
     JwtEncryptionBuilder keyEncryptionAlgorithm(KeyEncryptionAlgorithm algorithm);
 
     /**
-     * Set an 'enc' content encryption algorithm
+     * Set an 'enc' content encryption algorithm.
+     * Note that only 'A256GCM' (default) and 'A128CBC-HS256' algorithms must be supported.
      * 
      * @param algorithm the content encryption algorithm
      * @return JwtEncryptionBuilder
@@ -34,7 +37,7 @@ public interface JwtEncryptionBuilder extends JwtEncryption {
     JwtEncryptionBuilder contentEncryptionAlgorithm(ContentEncryptionAlgorithm algorithm);
 
     /**
-     * Set a 'kid' key encryption key id
+     * Set a 'kid' key encryption key id.
      * 
      * @param keyId the key id
      * @return JwtEncryptionBuilder
@@ -42,7 +45,7 @@ public interface JwtEncryptionBuilder extends JwtEncryption {
     JwtEncryptionBuilder keyEncryptionKeyId(String keyId);
 
     /**
-     * Custom JWT encryption header
+     * Custom JWT encryption header.
      * 
      * If the 'alg' (algorithm) header is set with this method then it
      * has to match one of the {@link KeyEncryptionAlgorithm} values.

--- a/implementation/src/main/java/io/smallrye/jwt/build/JwtSignature.java
+++ b/implementation/src/main/java/io/smallrye/jwt/build/JwtSignature.java
@@ -5,12 +5,14 @@ import java.security.PrivateKey;
 import javax.crypto.SecretKey;
 
 /**
- * JWT JsonWebSignature
+ * JWT JsonWebSignature.
  */
 public interface JwtSignature {
 
     /**
-     * Sign the claims with {@link PrivateKey}
+     * Sign the claims with {@link PrivateKey}.
+     * 'RS256' algorithm will be used unless a different one has been set with {@code JwtSignatureBuilder}.
+     * A key of size 2048 bits or larger MUST be used with the 'RS256' algorithm.
      * 
      * @param signingKey the signing key
      * @return signed JWT token
@@ -20,7 +22,9 @@ public interface JwtSignature {
 
     /**
      * Sign the claims with {@link SecretKey}
-     * 
+     * 'RS256' algorithm will be used unless a different one has been set with {@code JwtSignatureBuilder}.
+     * A key of size 2048 bits or larger MUST be used with the 'RS256' algorithm.
+     *
      * @param signingKey the signing key
      * @return signed JWT token
      * @throws JwtSignatureException the exception if the signing operation has failed
@@ -28,8 +32,23 @@ public interface JwtSignature {
     String sign(SecretKey signingKey) throws JwtSignatureException;
 
     /**
-     * Sign the claims with a key loaded from the location set with the "smallrye.jwt.sign.key-location" property.
+     * Sign the claims with a private or secret key loaded from the custom location
+     * which can point to a PEM, JWK or JWK set keys.
+     * 'RS256' algorithm will be used unless a different one has been set with {@code JwtSignatureBuilder}.
+     * A key of size 2048 bits or larger MUST be used with the 'RS256' algorithm.
      * 
+     * @param keyLocation the signing key location
+     * @return signed JWT token
+     * @throws JwtSignatureException the exception if the signing operation has failed
+     */
+    String sign(String keyLocation) throws JwtSignatureException;
+
+    /**
+     * Sign the claims with a key loaded from the location set with the "smallrye.jwt.sign.key-location" property
+     * which can point to a PEM, JWK or JWK set keys.
+     * 'RS256' algorithm will be used unless a different one has been set with {@code JwtSignatureBuilder}.
+     * A key of size 2048 bits or larger MUST be used with the 'RS256' algorithm.
+     *
      * @return signed JWT token
      * @throws JwtSignatureException the exception if the signing operation has failed
      */
@@ -37,6 +56,8 @@ public interface JwtSignature {
 
     /**
      * Sign the claims with {@link PrivateKey} and encrypt the inner JWT by moving to {@link JwtEncryption}.
+     * 'RS256' algorithm will be used unless a different one has been set with {@code JwtSignatureBuilder}.
+     * A key of size 2048 bits or larger MUST be used with the 'RS256' algorithm.
      *
      * @param signingKey the signing key
      * @return JwtEncryption
@@ -46,7 +67,9 @@ public interface JwtSignature {
 
     /**
      * Sign the claims with {@link SecretKey} and encrypt the inner JWT by moving to {@link JwtEncryptionBuilder}.
-     * 
+     * 'RS256' algorithm will be used unless a different one has been set with {@code JwtSignatureBuilder}.
+     * A key of size 2048 bits or larger MUST be used with the 'RS256' algorithm.
+     *
      * @param signingKey the signing key
      * @return JwtEncryption
      * @throws JwtSignatureException the exception if the inner JWT signing operation has failed
@@ -54,11 +77,24 @@ public interface JwtSignature {
     JwtEncryption innerSign(SecretKey signingKey) throws JwtSignatureException;
 
     /**
+     * Sign the claims with a private or secret key loaded from the custom location
+     * which can point to a PEM, JWK or JWK set keys and encrypt the inner JWT by moving to {@link JwtEncryptionBuilder}.
+     * 'RS256' algorithm will be used unless a different one has been set with {@code JwtSignatureBuilder}.
+     * A key of size 2048 bits or larger MUST be used with the 'RS256' algorithm.
+     *
+     * @param keyLocation the signing key location
+     * @return JwtEncryption
+     * @throws JwtSignatureException the exception if the inner JWT signing operation has failed
+     */
+    JwtEncryption innerSign(String keyLocation) throws JwtSignatureException;
+
+    /**
      * Sign the claims with a key loaded from the location set with the "smallrye.jwt.sign.key-location" property
      * and encrypt the inner JWT by moving to {@link JwtEncryptionBuilder}.
-     * 
-     * If no "smallrye.jwt.sign.key-location" property is set then an insecure inner JWT with a "none" algorithm
-     * has to be created before being encrypted.
+     *
+     * If no "smallrye.jwt.sign.key-location" property and 'alg' algorithm header have been set then an insecure
+     * inner JWT with a "none" algorithm has to be created before being encrypted.
+     * A key of size 2048 bits or larger MUST be used with the 'RS256' algorithm.
      * 
      * @return JwtEncryption
      * @throws JwtSignatureException the exception if the inner JWT signing operation has failed

--- a/implementation/src/main/java/io/smallrye/jwt/build/JwtSignatureBuilder.java
+++ b/implementation/src/main/java/io/smallrye/jwt/build/JwtSignatureBuilder.java
@@ -20,7 +20,8 @@ import io.smallrye.jwt.algorithm.SignatureAlgorithm;
 public interface JwtSignatureBuilder extends JwtSignature {
 
     /**
-     * Set a signature algorithm
+     * Set a signature algorithm.
+     * Note that only 'RS256' (default), 'ES256' and 'HS256' algorithms must be supported.
      * 
      * @param algorithm the signature algorithm
      * @return JwtSignatureBuilder
@@ -36,7 +37,7 @@ public interface JwtSignatureBuilder extends JwtSignature {
     JwtSignatureBuilder signatureKeyId(String keyId);
 
     /**
-     * Custom JWT signature header
+     * Custom JWT signature header.
      * 
      * If the 'alg' (algorithm) header is set with this method then it
      * has to match one of the {@link SignatureAlgorithm} values.


### PR DESCRIPTION
Fixes #174.
Fixes #173.
The main changes: 
- new `sign`, `innerSign` and `encrypt` methods which accept a key location. 
- enforcing RSA key size to 2048 bits
- better docs
- few more signature/enc algorithm enums