### PR TITLE
Add a key format property

### DIFF
--- a/implementation/src/main/java/io/smallrye/jwt/KeyFormat.java
+++ b/implementation/src/main/java/io/smallrye/jwt/KeyFormat.java
@@ -1,0 +1,30 @@
+package io.smallrye.jwt;
+
+/**
+ * Format or store type of the security key.
+ */
+public enum KeyFormat {
+    /**
+     * PEM file containing a Base64-encoded key.
+     */
+    PEM_KEY,
+    /**
+     * PEM file containing a Base64-encoded certificate.
+     */
+    PEM_CERTIFICATE,
+
+    /**
+     * JWK key set or single JWK key.
+     */
+    JWK,
+
+    /**
+     * JWK key set or single JWK key which has been Base64URL-encoded.
+     */
+    JWK_BASE64URL,
+
+    /**
+     * Key can be in any of the supported formats.
+     */
+    ANY
+}

--- a/implementation/src/main/java/io/smallrye/jwt/auth/principal/JWTAuthContextInfo.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/principal/JWTAuthContextInfo.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+import io.smallrye.jwt.KeyFormat;
 import io.smallrye.jwt.algorithm.SignatureAlgorithm;
 
 /**
@@ -45,6 +46,7 @@ public class JWTAuthContextInfo {
     private String groupsPath;
     private List<String> whitelistAlgorithms = new ArrayList<>();
     private SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.RS256;
+    private KeyFormat keyFormat = KeyFormat.ANY;
     private Set<String> expectedAudience;
     private String groupsSeparator = " ";
 
@@ -255,5 +257,13 @@ public class JWTAuthContextInfo {
 
     public void setSignatureAlgorithm(SignatureAlgorithm signatureAlgorithm) {
         this.signatureAlgorithm = signatureAlgorithm;
+    }
+
+    public KeyFormat getKeyFormat() {
+        return keyFormat;
+    }
+
+    public void setKeyFormat(KeyFormat keyFormat) {
+        this.keyFormat = keyFormat;
     }
 }

--- a/implementation/src/main/java/io/smallrye/jwt/config/JWTAuthContextInfoProvider.java
+++ b/implementation/src/main/java/io/smallrye/jwt/config/JWTAuthContextInfoProvider.java
@@ -30,6 +30,7 @@ import javax.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
+import io.smallrye.jwt.KeyFormat;
 import io.smallrye.jwt.KeyUtils;
 import io.smallrye.jwt.SmallryeJwtUtils;
 import io.smallrye.jwt.algorithm.SignatureAlgorithm;
@@ -89,6 +90,7 @@ public class JWTAuthContextInfoProvider {
         provider.maxTimeToLiveSecs = Optional.empty();
         provider.jwksRefreshInterval = Optional.empty();
         provider.signatureAlgorithm = Optional.of(SignatureAlgorithm.RS256);
+        provider.keyFormat = KeyFormat.ANY;
         provider.expectedAudience = Optional.empty();
         provider.groupsSeparator = DEFAULT_GROUPS_SEPARATOR;
 
@@ -244,6 +246,14 @@ public class JWTAuthContextInfoProvider {
     private Optional<SignatureAlgorithm> signatureAlgorithm;
 
     /**
+     * Supported key format. By default a key can be in any of the supported formats:
+     * PEM key, PEM certificate, JWK key set or single JWK (possibly Base64URL-encoded).
+     */
+    @Inject
+    @ConfigProperty(name = "smallrye.jwt.verify.key-format", defaultValue = "ANY")
+    private KeyFormat keyFormat;
+
+    /**
      * The audience value(s) that identify valid recipient(s) of a JWT. Audience validation
      * will succeed, if any one of the provided values is equal to any one of the values of
      * the "aud" claim in the JWT. The config value should be specified as a comma-separated
@@ -310,6 +320,7 @@ public class JWTAuthContextInfoProvider {
             throw new DeploymentException("HS256 verification algorithm is currently not supported");
         }
         contextInfo.setSignatureAlgorithm(signatureAlgorithm.orElse(SignatureAlgorithm.RS256));
+        contextInfo.setKeyFormat(keyFormat);
         contextInfo.setExpectedAudience(expectedAudience.orElse(null));
         contextInfo.setGroupsSeparator(groupsSeparator);
 
@@ -412,6 +423,10 @@ public class JWTAuthContextInfoProvider {
 
     public Optional<SignatureAlgorithm> getSignatureAlgorithm() {
         return signatureAlgorithm;
+    }
+
+    public KeyFormat getKeyFormat() {
+        return keyFormat;
     }
 
     public Optional<Set<String>> getExpectedAudience() {


### PR DESCRIPTION
`KeyFormat` property is introduced in preparation for #85 and also for `KeyLocationResolver` to avoid trying all the supported formats (in the worst cases, if it is HTTPS based Base64URL-encoded JWK set, the key will be loaded on the 5th attempt).

I've been thinking if `KeyStoreType` would be better given that it will be `JKS` which will be added next. But then for example an individual PEM key is not exactly a key store though it can be seen as such. So I've added a note in the docs it can be either the format or store type
