### PR TITLE
Add configuration to always check `Authorization` header

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -45,6 +45,7 @@ Smallrye JWT supports many properties which can be used to customize the token p
 |smallrye.jwt.verify.key-format|`ANY`|Set this property to a specific key format such as `PEM_KEY`, `PEM_CERTIFICATE`, `JWK` or `JWK_BASE64URL` to optimize the way the verification key is loaded.
 |smallrye.jwt.token.header|`Authorization`|Set this property if another header such as `Cookie` is used to pass the token.
 |smallrye.jwt.token.cookie|none|Name of the cookie containing a token. This property will be effective only if  `smallrye.jwt.token.header` is set to `Cookie`.
+|smallrye.jwt.always-check-authorization|false|If `true` the `Authorization` header is used if the cookie doesn't contain a token. This property will be effective only if  `smallrye.jwt.token.header` is set to `Cookie`.
 |smallrye.jwt.token.schemes|`Bearer`|Comma-separated list containing an alternative single or multiple schemes, for example, `DPoP`.
 |smallrye.jwt.token.kid|none|Key identifier. If it is set then the verification JWK key as well every JWT token must have a matching `kid` header.
 |smallrye.jwt.time-to-live|none|The maximum number of seconds that a JWT may be issued for use. Effectively, the difference between the expiration date of the JWT and the issued at date must not exceed this value.

--- a/README.adoc
+++ b/README.adoc
@@ -45,7 +45,7 @@ Smallrye JWT supports many properties which can be used to customize the token p
 |smallrye.jwt.verify.key-format|`ANY`|Set this property to a specific key format such as `PEM_KEY`, `PEM_CERTIFICATE`, `JWK` or `JWK_BASE64URL` to optimize the way the verification key is loaded.
 |smallrye.jwt.token.header|`Authorization`|Set this property if another header such as `Cookie` is used to pass the token.
 |smallrye.jwt.token.cookie|none|Name of the cookie containing a token. This property will be effective only if  `smallrye.jwt.token.header` is set to `Cookie`.
-|smallrye.jwt.always-check-authorization|false|If `true` the `Authorization` header is used if the cookie doesn't contain a token. This property will be effective only if  `smallrye.jwt.token.header` is set to `Cookie`.
+|smallrye.jwt.always-check-authorization|false|Set this property to `true` for `Authorization` header be checked even if the `smallrye.jwt.token.header` is set to `Cookie` but no cookie with a `smallrye.jwt.token.cookie` name exists.
 |smallrye.jwt.token.schemes|`Bearer`|Comma-separated list containing an alternative single or multiple schemes, for example, `DPoP`.
 |smallrye.jwt.token.kid|none|Key identifier. If it is set then the verification JWK key as well every JWT token must have a matching `kid` header.
 |smallrye.jwt.time-to-live|none|The maximum number of seconds that a JWT may be issued for use. Effectively, the difference between the expiration date of the JWT and the issued at date must not exceed this value.

--- a/implementation/src/main/java/io/smallrye/jwt/auth/AbstractBearerTokenExtractor.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/AbstractBearerTokenExtractor.java
@@ -52,12 +52,18 @@ public abstract class AbstractBearerTokenExtractor {
      */
     public String getBearerToken() {
         final String tokenHeaderName = authContextInfo.getTokenHeader();
+        final boolean fallbackToHeader = authContextInfo.isAlwaysCheckAutorization();
         LOGGER.debugf("tokenHeaderName = %s", tokenHeaderName);
 
         final String bearerValue;
 
         if (COOKIE_HEADER.equals(tokenHeaderName)) {
-            bearerValue = getBearerTokenCookie();
+            String intermediateBearerValue = getBearerTokenCookie();
+            if (intermediateBearerValue == null && fallbackToHeader) {
+                bearerValue = getBearerTokenAuthHeader();
+            } else {
+                bearerValue = intermediateBearerValue;
+            }
         } else if (AUTHORIZATION_HEADER.equals(tokenHeaderName)) {
             bearerValue = getBearerTokenAuthHeader();
         } else {

--- a/implementation/src/main/java/io/smallrye/jwt/auth/AbstractBearerTokenExtractor.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/AbstractBearerTokenExtractor.java
@@ -52,7 +52,7 @@ public abstract class AbstractBearerTokenExtractor {
      */
     public String getBearerToken() {
         final String tokenHeaderName = authContextInfo.getTokenHeader();
-        final boolean fallbackToHeader = authContextInfo.isAlwaysCheckAutorization();
+        final boolean fallbackToHeader = authContextInfo.isAlwaysCheckAuthorization();
         LOGGER.debugf("tokenHeaderName = %s", tokenHeaderName);
 
         final String bearerValue;

--- a/implementation/src/main/java/io/smallrye/jwt/auth/principal/JWTAuthContextInfo.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/principal/JWTAuthContextInfo.java
@@ -37,6 +37,7 @@ public class JWTAuthContextInfo {
     private Integer jwksRefreshInterval;
     private String tokenHeader = "Authorization";
     private String tokenCookie;
+    private boolean alwaysCheckAutorization;
     private String tokenKeyId;
     private List<String> tokenSchemes = Collections.singletonList("Bearer");
     private boolean requireNamedPrincipal = true;
@@ -266,4 +267,13 @@ public class JWTAuthContextInfo {
     public void setKeyFormat(KeyFormat keyFormat) {
         this.keyFormat = keyFormat;
     }
+
+    public boolean isAlwaysCheckAutorization() {
+        return alwaysCheckAutorization;
+    }
+
+    public void setAlwaysCheckAutorization(boolean alwaysCheckAutorization) {
+        this.alwaysCheckAutorization = alwaysCheckAutorization;
+    }
+
 }

--- a/implementation/src/main/java/io/smallrye/jwt/auth/principal/JWTAuthContextInfo.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/principal/JWTAuthContextInfo.java
@@ -37,7 +37,7 @@ public class JWTAuthContextInfo {
     private Integer jwksRefreshInterval;
     private String tokenHeader = "Authorization";
     private String tokenCookie;
-    private boolean alwaysCheckAutorization;
+    private boolean alwaysCheckAuthorization;
     private String tokenKeyId;
     private List<String> tokenSchemes = Collections.singletonList("Bearer");
     private boolean requireNamedPrincipal = true;
@@ -268,12 +268,12 @@ public class JWTAuthContextInfo {
         this.keyFormat = keyFormat;
     }
 
-    public boolean isAlwaysCheckAutorization() {
-        return alwaysCheckAutorization;
+    public boolean isAlwaysCheckAuthorization() {
+        return alwaysCheckAuthorization;
     }
 
-    public void setAlwaysCheckAutorization(boolean alwaysCheckAutorization) {
-        this.alwaysCheckAutorization = alwaysCheckAutorization;
+    public void setAlwaysCheckAuthorization(boolean alwaysCheckAuthorization) {
+        this.alwaysCheckAuthorization = alwaysCheckAuthorization;
     }
 
 }

--- a/implementation/src/main/java/io/smallrye/jwt/config/JWTAuthContextInfoProvider.java
+++ b/implementation/src/main/java/io/smallrye/jwt/config/JWTAuthContextInfoProvider.java
@@ -79,6 +79,7 @@ public class JWTAuthContextInfoProvider {
         provider.mpJwtRequireIss = Optional.of(Boolean.TRUE);
         provider.tokenHeader = AUTHORIZATION_HEADER;
         provider.tokenCookie = Optional.empty();
+        provider.alwaysCheckAuthorization = false;
         provider.tokenKeyId = Optional.empty();
         provider.tokenSchemes = Optional.of(BEARER_SCHEME);
         provider.requireNamedPrincipal = Optional.of(Boolean.TRUE);
@@ -142,8 +143,8 @@ public class JWTAuthContextInfoProvider {
     private Optional<String> tokenCookie;
 
     /**
-     * Should check `Authorization` header if cookie didn't contain a token. This property is ignored unless the
-     * "smallrye.jwt.token.header" is set to 'Cookie'
+     * If `true` then `Authorization` header will be checked even if the `smallrye.jwt.token.header` is set to `Cookie` but no
+     * cookie with a `smallrye.jwt.token.cookie` name exists.
      */
     @Inject
     @ConfigProperty(name = "smallrye.jwt.always-check-authorization", defaultValue = "false")
@@ -313,7 +314,7 @@ public class JWTAuthContextInfoProvider {
             contextInfo.setTokenHeader(tokenHeader);
         }
 
-        contextInfo.setAlwaysCheckAutorization(alwaysCheckAuthorization);
+        contextInfo.setAlwaysCheckAuthorization(alwaysCheckAuthorization);
 
         contextInfo.setTokenKeyId(tokenKeyId.orElse(null));
         contextInfo.setRequireNamedPrincipal(requireNamedPrincipal.orElse(null));
@@ -384,6 +385,10 @@ public class JWTAuthContextInfoProvider {
 
     public Optional<String> getTokenCookie() {
         return tokenCookie;
+    }
+
+    public boolean isAlwaysCheckAuthorization() {
+        return alwaysCheckAuthorization;
     }
 
     public Optional<String> getTokenKeyId() {

--- a/implementation/src/main/java/io/smallrye/jwt/config/JWTAuthContextInfoProvider.java
+++ b/implementation/src/main/java/io/smallrye/jwt/config/JWTAuthContextInfoProvider.java
@@ -79,7 +79,6 @@ public class JWTAuthContextInfoProvider {
         provider.mpJwtRequireIss = Optional.of(Boolean.TRUE);
         provider.tokenHeader = AUTHORIZATION_HEADER;
         provider.tokenCookie = Optional.empty();
-        provider.alwaysCheckAuthorization = false;
         provider.tokenKeyId = Optional.empty();
         provider.tokenSchemes = Optional.of(BEARER_SCHEME);
         provider.requireNamedPrincipal = Optional.of(Boolean.TRUE);

--- a/implementation/src/main/java/io/smallrye/jwt/config/JWTAuthContextInfoProvider.java
+++ b/implementation/src/main/java/io/smallrye/jwt/config/JWTAuthContextInfoProvider.java
@@ -142,6 +142,14 @@ public class JWTAuthContextInfoProvider {
     private Optional<String> tokenCookie;
 
     /**
+     * Should check `Authorization` header if cookie didn't contain a token. This property is ignored unless the
+     * "smallrye.jwt.token.header" is set to 'Cookie'
+     */
+    @Inject
+    @ConfigProperty(name = "smallrye.jwt.always-check-authorization", defaultValue = "false")
+    private boolean alwaysCheckAuthorization;
+
+    /**
      * The key identifier ('kid'). If it is set then if the token contains 'kid' then both values must match. It will also be
      * used to
      * select a JWK key from a JWK set.
@@ -304,6 +312,8 @@ public class JWTAuthContextInfoProvider {
         if (tokenHeader != null) {
             contextInfo.setTokenHeader(tokenHeader);
         }
+
+        contextInfo.setAlwaysCheckAutorization(alwaysCheckAuthorization);
 
         contextInfo.setTokenKeyId(tokenKeyId.orElse(null));
         contextInfo.setRequireNamedPrincipal(requireNamedPrincipal.orElse(null));

--- a/implementation/src/test/java/io/smallrye/jwt/auth/AbstractBearerTokenExtractorTest.java
+++ b/implementation/src/test/java/io/smallrye/jwt/auth/AbstractBearerTokenExtractorTest.java
@@ -172,7 +172,7 @@ public class AbstractBearerTokenExtractorTest {
     @Test
     public void testGetBearerTokenFallbackToHeaderWithCookieHeader() {
         when(authContextInfo.getTokenHeader()).thenReturn(COOKIE);
-        when(authContextInfo.isAlwaysCheckAutorization()).thenReturn(true);
+        when(authContextInfo.isAlwaysCheckAuthorization()).thenReturn(true);
         AbstractBearerTokenExtractor target = newTarget(h -> "Bearer THE_HEADER_TOKEN", c -> "THE_COOKIE_TOKEN");
         String bearerToken = target.getBearerToken();
         assertEquals("THE_COOKIE_TOKEN", bearerToken);
@@ -182,7 +182,7 @@ public class AbstractBearerTokenExtractorTest {
     public void testGetBearerTokenFallbackToHeaderWithEmptyCookie() {
         when(authContextInfo.getTokenHeader()).thenReturn(COOKIE);
         when(authContextInfo.getTokenSchemes()).thenReturn(BEARER_SCHEME);
-        when(authContextInfo.isAlwaysCheckAutorization()).thenReturn(true);
+        when(authContextInfo.isAlwaysCheckAuthorization()).thenReturn(true);
 
         AbstractBearerTokenExtractor target = newTarget(h -> "Bearer THE_TOKEN", c -> null);
         String bearerToken = target.getBearerToken();

--- a/implementation/src/test/java/io/smallrye/jwt/auth/AbstractBearerTokenExtractorTest.java
+++ b/implementation/src/test/java/io/smallrye/jwt/auth/AbstractBearerTokenExtractorTest.java
@@ -168,4 +168,24 @@ public class AbstractBearerTokenExtractorTest {
         String bearerToken = target.getBearerToken();
         assertNull(bearerToken);
     }
+
+    @Test
+    public void testGetBearerTokenFallbackToHeaderWithCookieHeader() {
+        when(authContextInfo.getTokenHeader()).thenReturn(COOKIE);
+        when(authContextInfo.isAlwaysCheckAutorization()).thenReturn(true);
+        AbstractBearerTokenExtractor target = newTarget(h -> "Bearer THE_HEADER_TOKEN", c -> "THE_COOKIE_TOKEN");
+        String bearerToken = target.getBearerToken();
+        assertEquals("THE_COOKIE_TOKEN", bearerToken);
+    }
+
+    @Test
+    public void testGetBearerTokenFallbackToHeaderWithEmptyCookie() {
+        when(authContextInfo.getTokenHeader()).thenReturn(COOKIE);
+        when(authContextInfo.getTokenSchemes()).thenReturn(BEARER_SCHEME);
+        when(authContextInfo.isAlwaysCheckAutorization()).thenReturn(true);
+
+        AbstractBearerTokenExtractor target = newTarget(h -> "Bearer THE_TOKEN", c -> null);
+        String bearerToken = target.getBearerToken();
+        assertEquals("THE_TOKEN", bearerToken);
+    }
 }


### PR DESCRIPTION
- add new property `smallrye.jwt.always-check-authorization` with default false
- evaluate `smallrye.jwt.always-check-authorization` in `AbstractBearerTokenExtractor` if set to true, fallback to `Authorization` header even if `tokenHeaderName` is set to `Cookie` but cookie is empty
- Add smallrye.jwt.always-check-authorization` in documentation with description

As discussed with @sberyozkin on zulipchat