### PR TITLE
Move version to 2.1

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.smallrye</groupId>
     <artifactId>smallrye-jwt-parent</artifactId>
-    <version>2.0.14-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>smallrye-jwt-docs</artifactId>

--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.smallrye</groupId>
     <artifactId>smallrye-jwt-parent</artifactId>
-    <version>2.0.14-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>smallrye-jwt</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <artifactId>smallrye-jwt-parent</artifactId>
-  <version>2.0.14-SNAPSHOT</version>
+  <version>2.1.0-SNAPSHOT</version>
 
   <packaging>pom</packaging>
   <name>SmallRye: MicroProfile JWT Parent</name>

--- a/release/pom.xml
+++ b/release/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-jwt-parent</artifactId>
-        <version>2.0.14-SNAPSHOT</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>smallrye-jwt-release</artifactId>

--- a/testsuite/basic/pom.xml
+++ b/testsuite/basic/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.smallrye</groupId>
     <artifactId>smallrye-jwt-testsuite-parent</artifactId>
-    <version>2.0.14-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>smallrye-jwt-testsuite-basic</artifactId>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.smallrye</groupId>
     <artifactId>smallrye-jwt-parent</artifactId>
-    <version>2.0.14-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <packaging>pom</packaging>


### PR DESCRIPTION
We have been discussing this week the need to be able to tag maintenance releases that contain bug fixes only without new enhancements, our integration within WildFly is now in the closing stages before we tag we should move to the next minor in case micro bug fix releases are needed.