### PR TITLE
Add constructor to allow manual dependency injection in tests

### DIFF
--- a/implementation/src/main/java/io/smallrye/jwt/auth/mechanism/JWTHttpAuthenticationMechanism.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/mechanism/JWTHttpAuthenticationMechanism.java
@@ -53,6 +53,17 @@ public class JWTHttpAuthenticationMechanism implements HttpAuthenticationMechani
     @Inject
     private PrincipalProducer producer;
 
+    public JWTHttpAuthenticationMechanism() {
+    }
+
+    public JWTHttpAuthenticationMechanism(JWTAuthContextInfo authContextInfo,
+                                          JWTParser jwtParser,
+                                          PrincipalProducer producer) {
+        this.authContextInfo = authContextInfo;
+        this.jwtParser = jwtParser;
+        this.producer = producer;
+    }
+
     @Override
     public AuthenticationStatus validateRequest(HttpServletRequest request,
             HttpServletResponse response,

--- a/implementation/src/main/java/io/smallrye/jwt/auth/principal/DefaultJWTParser.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/principal/DefaultJWTParser.java
@@ -32,6 +32,13 @@ public class DefaultJWTParser implements JWTParser {
 
     private volatile JWTCallerPrincipalFactory callerPrincipalFactory;
 
+    public DefaultJWTParser() {
+    }
+
+    public DefaultJWTParser(JWTAuthContextInfo authContextInfo) {
+        this.authContextInfo = authContextInfo;
+    }
+
     public JsonWebToken parse(final String bearerToken) throws ParseException {
         return getcallerPrincipalFactory().parse(bearerToken, authContextInfo);
     }


### PR DESCRIPTION
Currently the classes `JWTHttpAuthenticationMechanism.java` and `DefaultJWTParser.java` cannot be used in unit tests, since there is no way to inject their dependencies. This PR adds an additional constructor for manual dependency injection.