### PR TITLE
Make JWTCallerPrincipalFactory injectable

### DIFF
--- a/implementation/src/main/java/io/smallrye/jwt/auth/cdi/SmallRyeJWTAuthCDIExtension.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/cdi/SmallRyeJWTAuthCDIExtension.java
@@ -25,6 +25,7 @@ import javax.enterprise.inject.spi.Extension;
 
 import io.smallrye.jwt.auth.jaxrs.JWTAuthenticationFilter;
 import io.smallrye.jwt.auth.mechanism.JWTHttpAuthenticationMechanism;
+import io.smallrye.jwt.auth.principal.DefaultJWTCallerPrincipalFactory;
 import io.smallrye.jwt.auth.principal.DefaultJWTParser;
 import io.smallrye.jwt.config.JWTAuthContextInfoProvider;
 
@@ -80,6 +81,7 @@ public class SmallRyeJWTAuthCDIExtension implements Extension {
         addAnnotatedType(event, beanManager, ClaimValueProducer.class);
         addAnnotatedType(event, beanManager, CommonJwtProducer.class);
         addAnnotatedType(event, beanManager, DefaultJWTParser.class);
+        addAnnotatedType(event, beanManager, DefaultJWTCallerPrincipalFactory.class);
         addAnnotatedType(event, beanManager, JsonValueProducer.class);
         addAnnotatedType(event, beanManager, JWTAuthContextInfoProvider.class);
         addAnnotatedType(event, beanManager, JWTAuthenticationFilter.class);

--- a/implementation/src/main/java/io/smallrye/jwt/auth/principal/DefaultJWTCallerPrincipalFactory.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/principal/DefaultJWTCallerPrincipalFactory.java
@@ -16,21 +16,22 @@
  */
 package io.smallrye.jwt.auth.principal;
 
+import javax.enterprise.context.ApplicationScoped;
+
 import org.jose4j.jwt.consumer.JwtContext;
 
 /**
  * A default implementation of the abstract JWTCallerPrincipalFactory that uses the Keycloak token parsing classes.
  */
+@ApplicationScoped
 public class DefaultJWTCallerPrincipalFactory extends JWTCallerPrincipalFactory {
 
     private final DefaultJWTTokenParser parser = new DefaultJWTTokenParser();
 
     @Override
     public JWTCallerPrincipal parse(final String token, final JWTAuthContextInfo authContextInfo) throws ParseException {
-
         JwtContext jwtContext = parser.parse(token, authContextInfo);
         String type = jwtContext.getJoseObjects().get(0).getHeader("typ");
         return new DefaultJWTCallerPrincipal(type, jwtContext.getJwtClaims());
     }
-
 }

--- a/implementation/src/main/java/io/smallrye/jwt/auth/principal/DefaultJWTParser.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/principal/DefaultJWTParser.java
@@ -38,18 +38,23 @@ public class DefaultJWTParser implements JWTParser {
 
     @Inject
     private JWTAuthContextInfo authContextInfo;
-
-    private volatile JWTCallerPrincipalFactory callerPrincipalFactory;
+    @Inject
+    private JWTCallerPrincipalFactory callerPrincipalFactory;
 
     public DefaultJWTParser() {
     }
 
     public DefaultJWTParser(JWTAuthContextInfo authContextInfo) {
+        this(authContextInfo, JWTCallerPrincipalFactory.instance());
+    }
+
+    public DefaultJWTParser(JWTAuthContextInfo authContextInfo, JWTCallerPrincipalFactory callerPrincipalFactory) {
         this.authContextInfo = authContextInfo;
+        this.callerPrincipalFactory = callerPrincipalFactory;
     }
 
     public JsonWebToken parse(final String bearerToken) throws ParseException {
-        return getCallerPrincipalFactory().parse(bearerToken, authContextInfo);
+        return callerPrincipalFactory.parse(bearerToken, authContextInfo);
     }
 
     @Override
@@ -99,11 +104,7 @@ public class DefaultJWTParser implements JWTParser {
 
     private JWTCallerPrincipalFactory getCallerPrincipalFactory() {
         if (callerPrincipalFactory == null) {
-            synchronized (this) {
-                if (callerPrincipalFactory == null) {
-                    callerPrincipalFactory = JWTCallerPrincipalFactory.instance();
-                }
-            }
+            return JWTCallerPrincipalFactory.instance();
         }
         return callerPrincipalFactory;
     }


### PR DESCRIPTION
This PR allows injecting own implementatons of the `JWTCallerPrincipalFactory` into the `DefaultJWTParser`.

Edit: I don't think the `JWTCallerPrincipalFactory.instance()` method should be removed, since it allows a simple entrance into the library. However, since the `DefaultJWTParser` already uses injection, both dependencies should be injected the same way for easier testability and configurability.


Fixes #193. 
