### PR TITLE
Support the cases when groups is a string or complex object

### DIFF
--- a/testsuite/basic/src/test/java/io/smallrye/jwt/TestTokenWithGroupsPath2.java
+++ b/testsuite/basic/src/test/java/io/smallrye/jwt/TestTokenWithGroupsPath2.java
@@ -1,0 +1,80 @@
+/*
+ *   Copyright 2020 Red Hat, Inc, and individual contributors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package io.smallrye.jwt;
+
+import static org.eclipse.microprofile.jwt.tck.TCKConstants.TEST_GROUP_JWT;
+import static org.eclipse.microprofile.jwt.tck.TCKConstants.TEST_ISSUER;
+
+import java.security.PublicKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.HashMap;
+import java.util.Set;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.eclipse.microprofile.jwt.tck.util.TokenUtils;
+import org.jboss.arquillian.testng.Arquillian;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import io.smallrye.jwt.auth.principal.JWTAuthContextInfo;
+import io.smallrye.jwt.auth.principal.JWTCallerPrincipalFactory;
+
+/**
+ * A more extensive test of the how the token JSON content types are mapped
+ * to values via the JsonWebToken implementation.
+ */
+public class TestTokenWithGroupsPath2 extends Arquillian {
+    /** The test generated JWT token string */
+    private static String token;
+    /** The /publicKey.pem instance */
+    private static PublicKey publicKey;
+
+    @BeforeClass(alwaysRun = true)
+    public static void generateToken() throws Exception {
+        HashMap<String, Long> timeClaims = new HashMap<>();
+        token = TokenUtils.generateTokenString("/TokenGroupsPath2.json", null, timeClaims);
+        publicKey = TokenUtils.readPublicKey("/publicKey.pem");
+        if (publicKey == null) {
+            throw new IllegalStateException("Failed to load /publicKey.pem resource");
+        }
+    }
+
+    @Test(groups = TEST_GROUP_JWT, description = "validate the custom path starting from groups")
+    public void groupsObject() throws Exception {
+        JWTAuthContextInfo contextInfo = new JWTAuthContextInfo((RSAPublicKey) publicKey, TEST_ISSUER);
+        contextInfo.setGroupsPath("groups/array");
+        JWTCallerPrincipalFactory factory = JWTCallerPrincipalFactory.instance();
+        JsonWebToken jwt = factory.parse(token, contextInfo);
+        Set<String> groups = jwt.getGroups();
+        Assert.assertEquals(groups.size(), 1);
+        Assert.assertTrue(groups.contains("microprofile_jwt_user"));
+    }
+
+    @Test(groups = TEST_GROUP_JWT, description = "validate the custom path starting from groups and ending with the string")
+    public void groupsString() throws Exception {
+        JWTAuthContextInfo contextInfo = new JWTAuthContextInfo((RSAPublicKey) publicKey, TEST_ISSUER);
+        contextInfo.setGroupsPath("groups/groups");
+        contextInfo.setGroupsSeparator(",");
+        JWTCallerPrincipalFactory factory = JWTCallerPrincipalFactory.instance();
+        JsonWebToken jwt = factory.parse(token, contextInfo);
+        Set<String> groups = jwt.getGroups();
+        Assert.assertEquals(groups.size(), 2);
+        Assert.assertTrue(groups.contains("microprofile_jwt_user1"));
+        Assert.assertTrue(groups.contains("microprofile_jwt_user2"));
+    }
+}

--- a/testsuite/basic/src/test/java/io/smallrye/jwt/TestTokenWithGroupsString.java
+++ b/testsuite/basic/src/test/java/io/smallrye/jwt/TestTokenWithGroupsString.java
@@ -1,0 +1,67 @@
+/*
+ *   Copyright 2020 Red Hat, Inc, and individual contributors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package io.smallrye.jwt;
+
+import static org.eclipse.microprofile.jwt.tck.TCKConstants.TEST_GROUP_JWT;
+import static org.eclipse.microprofile.jwt.tck.TCKConstants.TEST_ISSUER;
+
+import java.security.PublicKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.HashMap;
+import java.util.Set;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.eclipse.microprofile.jwt.tck.util.TokenUtils;
+import org.jboss.arquillian.testng.Arquillian;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import io.smallrye.jwt.auth.principal.JWTAuthContextInfo;
+import io.smallrye.jwt.auth.principal.JWTCallerPrincipalFactory;
+
+/**
+ * A more extensive test of the how the token JSON content types are mapped
+ * to values via the JsonWebToken implementation.
+ */
+public class TestTokenWithGroupsString extends Arquillian {
+    /** The test generated JWT token string */
+    private static String token;
+    /** The /publicKey.pem instance */
+    private static PublicKey publicKey;
+
+    @BeforeClass(alwaysRun = true)
+    public static void generateToken() throws Exception {
+        HashMap<String, Long> timeClaims = new HashMap<>();
+        token = TokenUtils.generateTokenString("/TokenGroupsString.json", null, timeClaims);
+        publicKey = TokenUtils.readPublicKey("/publicKey.pem");
+        if (publicKey == null) {
+            throw new IllegalStateException("Failed to load /publicKey.pem resource");
+        }
+    }
+
+    @Test(groups = TEST_GROUP_JWT, description = "validate the groups string claims with multiple roles")
+    public void groupsString() throws Exception {
+        JWTAuthContextInfo contextInfo = new JWTAuthContextInfo((RSAPublicKey) publicKey, TEST_ISSUER);
+        JWTCallerPrincipalFactory factory = JWTCallerPrincipalFactory.instance();
+        JsonWebToken jwt = factory.parse(token, contextInfo);
+        Set<String> groups = jwt.getGroups();
+        Assert.assertEquals(groups.size(), 2);
+        Assert.assertTrue(groups.contains("role1"));
+        Assert.assertTrue(groups.contains("role2"));
+    }
+}

--- a/testsuite/basic/src/test/resources/TokenGroupsPath2.json
+++ b/testsuite/basic/src/test/resources/TokenGroupsPath2.json
@@ -1,0 +1,19 @@
+{
+    "iss": "https://server.example.com",
+    "jti": "a-123",
+    "sub": "24400320",
+    "upn": "jdoe@example.com",
+    "preferred_username": "jdoe",
+    "aud": "s6BhdRkqt3",
+    "exp": 1311281970,
+    "iat": 1311280970,
+    "auth_time": 1311280969,
+    "groups": {
+        "array": [
+          "microprofile_jwt_user"
+        ],
+        "groups":"microprofile_jwt_user1,microprofile_jwt_user2"
+    },
+    "scope": "read write",
+    "auth": "read,write"
+}

--- a/testsuite/basic/src/test/resources/TokenGroupsString.json
+++ b/testsuite/basic/src/test/resources/TokenGroupsString.json
@@ -1,0 +1,14 @@
+{
+    "iss": "https://server.example.com",
+    "jti": "a-123",
+    "sub": "24400320",
+    "upn": "jdoe@example.com",
+    "preferred_username": "jdoe",
+    "aud": "s6BhdRkqt3",
+    "exp": 1311281970,
+    "iat": 1311280970,
+    "auth_time": 1311280969,
+    "groups": "role1 role2",
+    "scope": "read write",
+    "auth": "read,write"
+}


### PR DESCRIPTION
This PR adds a support for tokens where `groups` is a string (reported by a Quarkus Ping Identity user), I've also updated the code to support `groups` being a complex object