### PR TITLE
Correction due to build time formatting.

### DIFF
--- a/implementation/src/main/java/io/smallrye/jwt/auth/mechanism/JWTHttpAuthenticationMechanism.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/mechanism/JWTHttpAuthenticationMechanism.java
@@ -57,8 +57,8 @@ public class JWTHttpAuthenticationMechanism implements HttpAuthenticationMechani
     }
 
     public JWTHttpAuthenticationMechanism(JWTAuthContextInfo authContextInfo,
-                                          JWTParser jwtParser,
-                                          PrincipalProducer producer) {
+            JWTParser jwtParser,
+            PrincipalProducer producer) {
         this.authContextInfo = authContextInfo;
         this.jwtParser = jwtParser;
         this.producer = producer;


### PR DESCRIPTION
Building locally the build time formatting is modifying the source, this PR just contains the modifications.

I am not sure how but could be nice if CI could fail builds that result in formatting changes as it is a sign formatting has not occurred before the commit was made.
