### PR TITLE
Add TCK tests to project.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
     <version.io.smallrye.config>1.7.0</version.io.smallrye.config>
     <version.microprofile.config>1.4</version.microprofile.config>
     <version.jose4j>0.7.0</version.jose4j>
+    <version.resteasy>3.9.1.Final</version.resteasy>
     <version.mokito>3.3.3</version.mokito>
     <version.weld-junit4>2.0.1.Final</version.weld-junit4>
     <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/testsuite/basic/target/site/jacoco-aggregate/jacoco.xml,${project.basedir}/../testsuite/basic/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -30,6 +30,7 @@
 
   <modules>
     <module>basic</module>
+    <module>tck</module>
   </modules>
   <build>
     <plugins>

--- a/testsuite/tck/pom.xml
+++ b/testsuite/tck/pom.xml
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ ~  Copyright 2017 Red Hat, Inc.
+ ~
+ ~  Licensed under the Apache License, Version 2.0 (the "License");
+ ~  you may not use this file except in compliance with the License.
+ ~  You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~  Unless required by applicable law or agreed to in writing, software
+ ~  distributed under the License is distributed on an "AS IS" BASIS,
+ ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~  See the License for the specific language governing permissions and
+ ~  limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.smallrye</groupId>
+    <artifactId>smallrye-jwt-testsuite-parent</artifactId>
+    <version>2.1.2-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>smallrye-jwt-tck</artifactId>
+
+  <name>SmallRye: MicroProfile JWT TCK</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.smallrye</groupId>
+      <artifactId>smallrye-jwt</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.weld.servlet</groupId>
+      <artifactId>weld-servlet-core</artifactId>
+      <version>${version.weld.core}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-servlet-initializer</artifactId>
+      <version>${version.resteasy}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jaxrs</artifactId>
+      <version>${version.resteasy}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-client</artifactId>
+      <version>${version.resteasy}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-cdi</artifactId>
+      <version>${version.resteasy}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-json-binding-provider</artifactId>
+      <version>${version.resteasy}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.microprofile.jwt</groupId>
+      <artifactId>microprofile-jwt-auth-tck</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.microprofile.jwt</groupId>
+      <artifactId>microprofile-jwt-auth-tck</artifactId>
+      <type>test-jar</type>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.arquillian.container</groupId>
+      <artifactId>arquillian-container-spi</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <suiteXmlFiles>
+            <suiteXmlFile>${project.build.directory}/test-classes/tck-base-suite.xml</suiteXmlFile>
+          </suiteXmlFiles>
+          <dependenciesToScan>
+            <dependency>org.eclipse.microprofile.jwt:microprofile-jwt-auth-tck</dependency>
+          </dependenciesToScan>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>wildfly-servlet</id>
+      <activation>
+        <property>
+          <!-- use property rather than activeByDefault, see https://issues.apache.org/jira/browse/MNG-4917 -->
+          <name>!noWildflyServlet</name>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.wildfly.arquillian</groupId>
+          <artifactId>wildfly-arquillian-container-managed</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <environmentVariables>
+                <JBOSS_HOME>${project.build.directory}/wildfly-servlet-${version.wildfly}</JBOSS_HOME>
+              </environmentVariables>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>unpack</id>
+                <phase>process-test-classes</phase>
+                <goals>
+                  <goal>unpack</goal>
+                </goals>
+                <configuration>
+                  <artifactItems>
+                    <artifactItem>
+                      <groupId>org.wildfly</groupId>
+                      <artifactId>wildfly-servlet-dist</artifactId>
+                      <version>${version.wildfly}</version>
+                      <type>zip</type>
+                      <overWrite>false</overWrite>
+                      <outputDirectory>${project.build.directory}</outputDirectory>
+                    </artifactItem>
+                  </artifactItems>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>coverage</id>
+      <properties>
+          <argLine>@{jacocoArgLine}</argLine>
+      </properties>
+
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>report-aggregate</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>report-aggregate</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    </profiles>
+</project>

--- a/testsuite/tck/pom.xml
+++ b/testsuite/tck/pom.xml
@@ -34,6 +34,10 @@
       <artifactId>smallrye-jwt</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.smallrye.config</groupId>
+      <artifactId>smallrye-config</artifactId>
+    </dependency>
+    <dependency>
       <groupId>jakarta.servlet</groupId>
       <artifactId>jakarta.servlet-api</artifactId>
       <scope>provided</scope>

--- a/testsuite/tck/src/test/java/io/smallrye/jwt/tck/OptionalAwareSmallRyeJWTAuthCDIExtension.java
+++ b/testsuite/tck/src/test/java/io/smallrye/jwt/tck/OptionalAwareSmallRyeJWTAuthCDIExtension.java
@@ -1,0 +1,12 @@
+package io.smallrye.jwt.tck;
+
+import io.smallrye.jwt.auth.cdi.SmallRyeJWTAuthCDIExtension;
+
+public class OptionalAwareSmallRyeJWTAuthCDIExtension extends SmallRyeJWTAuthCDIExtension {
+    // TODO - radcortez - This should be changed in the original extension. This is how Elytron is doing it.
+    // Maybe because difference between 1.0 and 1.1? Right now it doesn't make sense to keeo it as is, since it will fail the TCK.
+    @Override
+    protected boolean registerOptionalClaimTypeProducer() {
+        return true;
+    }
+}

--- a/testsuite/tck/src/test/java/io/smallrye/jwt/tck/SmallRyeJWTArchiveProcessor.java
+++ b/testsuite/tck/src/test/java/io/smallrye/jwt/tck/SmallRyeJWTArchiveProcessor.java
@@ -3,7 +3,6 @@ package io.smallrye.jwt.tck;
 import java.io.File;
 
 import javax.enterprise.inject.spi.Extension;
-import javax.ws.rs.ext.Providers;
 
 import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
 import org.jboss.arquillian.test.spi.TestClass;
@@ -11,16 +10,14 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 
-import io.smallrye.jwt.auth.jaxrs.JWTAuthenticationFilter;
-
 public class SmallRyeJWTArchiveProcessor implements ApplicationArchiveProcessor {
     @Override
     public void process(Archive<?> applicationArchive, TestClass testClass) {
         if (applicationArchive instanceof WebArchive) {
             WebArchive war = (WebArchive) applicationArchive;
             war.addClass(OptionalAwareSmallRyeJWTAuthCDIExtension.class);
+            war.addClass(SmallRyeJWTAuthJaxRsFeature.class);
             war.addAsServiceProvider(Extension.class, OptionalAwareSmallRyeJWTAuthCDIExtension.class);
-            war.addAsServiceProvider(Providers.class, JWTAuthenticationFilter.class);
 
             if (!war.contains("META-INF/microprofile-config.properties")) {
                 war.addAsManifestResource("microprofile-config-local.properties", "microprofile-config.properties");

--- a/testsuite/tck/src/test/java/io/smallrye/jwt/tck/SmallRyeJWTArchiveProcessor.java
+++ b/testsuite/tck/src/test/java/io/smallrye/jwt/tck/SmallRyeJWTArchiveProcessor.java
@@ -23,6 +23,10 @@ public class SmallRyeJWTArchiveProcessor implements ApplicationArchiveProcessor 
                 war.addAsManifestResource("microprofile-config-local.properties", "microprofile-config.properties");
             }
 
+            // A few tests require the apps to be deployed in the root. Check PublicKeyAsJWKLocationURLTest and PublicKeyAsPEMLocationURLTest
+            // Both tests set the public key location url to be in root.
+            war.addAsWebInfResource("jboss-web.xml");
+
             String[] deps = {
                     "io.smallrye:smallrye-jwt",
                     "io.smallrye.config:smallrye-config",

--- a/testsuite/tck/src/test/java/io/smallrye/jwt/tck/SmallRyeJWTArchiveProcessor.java
+++ b/testsuite/tck/src/test/java/io/smallrye/jwt/tck/SmallRyeJWTArchiveProcessor.java
@@ -1,0 +1,36 @@
+package io.smallrye.jwt.tck;
+
+import java.io.File;
+
+import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
+import org.jboss.arquillian.test.spi.TestClass;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+
+public class SmallRyeJWTArchiveProcessor implements ApplicationArchiveProcessor {
+    @Override
+    public void process(Archive<?> applicationArchive, TestClass testClass) {
+        if (applicationArchive instanceof WebArchive) {
+            WebArchive war = (WebArchive) applicationArchive;
+
+            String[] deps = {
+                    "io.smallrye:smallrye-jwt",
+                    "org.jboss.resteasy:resteasy-servlet-initializer",
+                    "org.jboss.resteasy:resteasy-jaxrs",
+                    "org.jboss.resteasy:resteasy-client",
+                    "org.jboss.resteasy:resteasy-cdi",
+                    "org.jboss.resteasy:resteasy-json-binding-provider",
+                    "org.jboss.weld.servlet:weld-servlet-core"
+            };
+            File[] dependencies = Maven.resolver()
+                    .loadPomFromFile(new File("pom.xml"))
+                    .resolve(deps)
+                    .withTransitivity()
+                    .asFile();
+
+            war.addAsLibraries(dependencies);
+            System.out.println(war.toString(true));
+        }
+    }
+}

--- a/testsuite/tck/src/test/java/io/smallrye/jwt/tck/SmallRyeJWTArchiveProcessor.java
+++ b/testsuite/tck/src/test/java/io/smallrye/jwt/tck/SmallRyeJWTArchiveProcessor.java
@@ -2,20 +2,33 @@ package io.smallrye.jwt.tck;
 
 import java.io.File;
 
+import javax.enterprise.inject.spi.Extension;
+import javax.ws.rs.ext.Providers;
+
 import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
 import org.jboss.arquillian.test.spi.TestClass;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 
+import io.smallrye.jwt.auth.jaxrs.JWTAuthenticationFilter;
+
 public class SmallRyeJWTArchiveProcessor implements ApplicationArchiveProcessor {
     @Override
     public void process(Archive<?> applicationArchive, TestClass testClass) {
         if (applicationArchive instanceof WebArchive) {
             WebArchive war = (WebArchive) applicationArchive;
+            war.addClass(OptionalAwareSmallRyeJWTAuthCDIExtension.class);
+            war.addAsServiceProvider(Extension.class, OptionalAwareSmallRyeJWTAuthCDIExtension.class);
+            war.addAsServiceProvider(Providers.class, JWTAuthenticationFilter.class);
+
+            if (!war.contains("META-INF/microprofile-config.properties")) {
+                war.addAsManifestResource("microprofile-config-local.properties", "microprofile-config.properties");
+            }
 
             String[] deps = {
                     "io.smallrye:smallrye-jwt",
+                    "io.smallrye.config:smallrye-config",
                     "org.jboss.resteasy:resteasy-servlet-initializer",
                     "org.jboss.resteasy:resteasy-jaxrs",
                     "org.jboss.resteasy:resteasy-client",
@@ -30,7 +43,6 @@ public class SmallRyeJWTArchiveProcessor implements ApplicationArchiveProcessor 
                     .asFile();
 
             war.addAsLibraries(dependencies);
-            System.out.println(war.toString(true));
         }
     }
 }

--- a/testsuite/tck/src/test/java/io/smallrye/jwt/tck/SmallRyeJWTAuthJaxRsFeature.java
+++ b/testsuite/tck/src/test/java/io/smallrye/jwt/tck/SmallRyeJWTAuthJaxRsFeature.java
@@ -1,0 +1,12 @@
+package io.smallrye.jwt.tck;
+
+import javax.ws.rs.ext.Provider;
+
+/**
+ * This is to register the JAX-RS Feature to add the SmallRye JWT Filters. This cannot be registed as a Provider
+ * Service Loader, because it would initialize before the JAX-RS Application is available in the Context. This is
+ * required to check the LoginModule in the Application class and provide correct registration of the filters.
+ */
+@Provider
+public class SmallRyeJWTAuthJaxRsFeature extends io.smallrye.jwt.auth.jaxrs.SmallRyeJWTAuthJaxRsFeature {
+}

--- a/testsuite/tck/src/test/java/io/smallrye/jwt/tck/SmallRyeJWTExtension.java
+++ b/testsuite/tck/src/test/java/io/smallrye/jwt/tck/SmallRyeJWTExtension.java
@@ -1,0 +1,11 @@
+package io.smallrye.jwt.tck;
+
+import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+
+public class SmallRyeJWTExtension implements LoadableExtension {
+    @Override
+    public void register(final ExtensionBuilder builder) {
+        builder.service(ApplicationArchiveProcessor.class, SmallRyeJWTArchiveProcessor.class);
+    }
+}

--- a/testsuite/tck/src/test/java/io/smallrye/jwt/tck/TestApplication.java
+++ b/testsuite/tck/src/test/java/io/smallrye/jwt/tck/TestApplication.java
@@ -1,0 +1,99 @@
+package io.smallrye.jwt.tck;
+
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.enterprise.context.RequestScoped;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ArchivePaths;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestApplication extends Arquillian {
+    /**
+     * The base URL for the container under test
+     */
+    @ArquillianResource
+    private URL baseURL;
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        return ShrinkWrap
+                .create(WebArchive.class)
+                .addClass(TestServlet.class)
+                .addClass(RestApplication.class)
+                .addClass(TestEndpoint.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, ArchivePaths.create("beans.xml"));
+    }
+
+    @Test
+    @RunAsClient
+    public void servlet() throws Exception {
+        String uri = baseURL.toExternalForm() + "servlet";
+        System.out.println("uri = " + uri);
+        WebTarget echoEndpointTarget = ClientBuilder.newClient().target(uri);
+        Response response = echoEndpointTarget.request(TEXT_PLAIN).get();
+        Assert.assertEquals(response.getStatus(), HttpURLConnection.HTTP_OK);
+    }
+
+    @Test
+    @RunAsClient
+    public void rest() throws Exception {
+        String uri = baseURL.toExternalForm() + "rest";
+        System.out.println("uri = " + uri);
+        WebTarget echoEndpointTarget = ClientBuilder.newClient().target(uri);
+        Response response = echoEndpointTarget.request(TEXT_PLAIN).get();
+        Assert.assertEquals(response.getStatus(), HttpURLConnection.HTTP_OK);
+    }
+
+    @WebServlet(urlPatterns = "/servlet")
+    public static class TestServlet extends HttpServlet {
+        @Override
+        protected void doGet(final HttpServletRequest req, final HttpServletResponse resp)
+                throws ServletException, IOException {
+            resp.getWriter().write("hello");
+        }
+    }
+
+    @ApplicationPath("/rest")
+    public static class RestApplication extends javax.ws.rs.core.Application {
+        @Override
+        public Set<Class<?>> getClasses() {
+            final HashSet<Class<?>> classes = new HashSet<>();
+            classes.add(TestEndpoint.class);
+            return classes;
+        }
+    }
+
+    @RequestScoped
+    @Path("/")
+    public static class TestEndpoint {
+        @GET
+        public String hello() {
+            return "hello";
+        }
+    }
+}

--- a/testsuite/tck/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/testsuite/tck/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+io.smallrye.jwt.tck.SmallRyeJWTExtension

--- a/testsuite/tck/src/test/resources/arquillian.xml
+++ b/testsuite/tck/src/test/resources/arquillian.xml
@@ -1,0 +1,15 @@
+<arquillian xmlns="http://jboss.org/schema/arquillian"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="
+        http://jboss.org/schema/arquillian
+        http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+  <container qualifier="jbossas-managed" default="true">
+    <configuration>
+      <!--
+      <property name="javaVmArguments">
+        -Xmx512m -XX:MaxPermSize=128m -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y
+      </property>
+      -->
+    </configuration>
+  </container>
+</arquillian>

--- a/testsuite/tck/src/test/resources/jboss-web.xml
+++ b/testsuite/tck/src/test/resources/jboss-web.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<jboss-web version="14.1" xmlns="http://www.jboss.com/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xsi:schemaLocation="http://www.jboss.com/xml/ns/javaee http://www.jboss.org/schema/jbossas/jboss-web_14_1.xsd">
+
+    <context-root>/</context-root>
+
+</jboss-web>

--- a/testsuite/tck/src/test/resources/microprofile-config-local.properties
+++ b/testsuite/tck/src/test/resources/microprofile-config-local.properties
@@ -1,0 +1,2 @@
+mp.jwt.verify.publickey.location=publicKey.pem
+mp.jwt.verify.issuer=https://server.example.com

--- a/testsuite/tck/src/test/resources/tck-base-suite.xml
+++ b/testsuite/tck/src/test/resources/tck-base-suite.xml
@@ -1,0 +1,69 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<!--
+    Licensed under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<suite name="microprofile-jwt-auth-BaseTCK" verbose="1" preserve-order="true" configfailurepolicy="continue" >
+
+    <!-- The required base JAX-RS and CDI based tests that all MP-JWT implementations
+    must pass.
+    -->
+    <test name="base-tests" verbose="10">
+        <groups>
+            <define name="base-groups">
+                <include name="arquillian" description="Arquillian internal"/>
+                <include name="utils" description="Utility tests"/>
+                <include name="jwt" description="Base JsonWebToken tests"/>
+                <include name="jaxrs" description="JAX-RS invocation tests"/>
+                <include name="cdi" description="Base CDI injection of ClaimValues"/>
+                <include name="cdi-json" description="CDI injection of JSON-P values"/>
+                <include name="cdi-provider" description="CDI injection of javax.inject.Provider values"/>
+                <include name="config" description="Validate configuration using MP-config"/>
+            </define>
+            <define name="excludes">
+                <include name="debug" description="Internal debugging tests" />
+            </define>
+            <run>
+                <include name="base-groups" />
+                <exclude name="excludes" />
+            </run>
+        </groups>
+        <classes>
+            <class name="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.UnsecuredPingTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.InvalidTokenTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrincipalInjectionTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsPEMTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsPEMLocationTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsPEMLocationURLTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKLocationTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKLocationURLTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKSTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKSLocationTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsBase64JWKTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsFileLocationURLTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.config.IssNoValidationNoIssTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.config.IssNoValidationBadIssTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.config.IssValidationTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.config.IssValidationFailTest" />
+        </classes>
+    </test>
+
+</suite>


### PR DESCRIPTION
Here is the initial work to run the TCK directly in the project.

Still some tests failures, probably related with missing setup that need to be debugged on a case by case basis.

This is using `io.smallrye.jwt.auth.jaxrs.JWTAuthenticationFilter` to apply the security context.

A few considerations:
- It seems the filters are not used either in Elytron (uses their internal HttpServerAuthenticationMechanism) or Quarkus (they implement their own with Vert.x).
- The filters were not being testes previously, so some of the failures related with the filters I'm not sure if they are cause by the setup or some bug in the filter.
- Do we want to keep the filters and change them is required? Is anyone else using them?
- The `SmallRyeJWTAuthCDIExtension` has Optional injection turned off by default, but this is required to pass the TCK. I'm wondering if this was something between 1.0 and 1.1? Elytron extends the extension and turn that on. I think we should just turn that on by default.
