### PR TITLE
Add documentation for smallrye encrypt and sign properties

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -59,6 +59,8 @@ Smallrye JWT supports many properties which can be used to customize the token p
 |smallrye.jwt.expiration.grace|60|Expiration grace in seconds. By default an expired token will still be accepted if the current time is no more than 1 min after the token expiry time.
 |smallrye.jwt.verify.aud|none|Comma separated list of the audiences that a token `aud` claim may contain.
 |smallrye.jwt.required.claims|none|Comma separated list of the claims that a token must contain.
+|smallrye.jwt.encrypt.key-location|none|Config property allows the location of a key to be specified which will be used to encrypt the claims or inner JWT.
+|smallrye.jwt.sign.key-location|none|Config property allows the location of a private key to be specified which will be used to sign the claims of a JWT.
 |===
 
 == Instructions

--- a/README.adoc
+++ b/README.adoc
@@ -59,8 +59,6 @@ Smallrye JWT supports many properties which can be used to customize the token p
 |smallrye.jwt.expiration.grace|60|Expiration grace in seconds. By default an expired token will still be accepted if the current time is no more than 1 min after the token expiry time.
 |smallrye.jwt.verify.aud|none|Comma separated list of the audiences that a token `aud` claim may contain.
 |smallrye.jwt.required.claims|none|Comma separated list of the claims that a token must contain.
-|smallrye.jwt.encrypt.key-location|none|Config property allows the location of a key to be specified which will be used to encrypt the claims or inner JWT.
-|smallrye.jwt.sign.key-location|none|Config property allows the location of a private key to be specified which will be used to sign the claims of a JWT.
 |===
 
 == Instructions

--- a/doc/modules/ROOT/pages/generate-jwt.adoc
+++ b/doc/modules/ROOT/pages/generate-jwt.adoc
@@ -18,7 +18,7 @@ SmallRye JWT provides an API for securing the JWT claims using all of these opti
 == Configuration
 === Smallrye JWT properties
 
-Smallrye JWT supports many properties which can be used to customize the token processing:
+Smallrye JWT supports the following properties which can be used to customize the way claims are signed and encrypted:
 
 [cols="<m,<m,<2",options="header"]
 |===

--- a/doc/modules/ROOT/pages/generate-jwt.adoc
+++ b/doc/modules/ROOT/pages/generate-jwt.adoc
@@ -15,6 +15,18 @@ encrypting the nested JWT token.
 
 SmallRye JWT provides an API for securing the JWT claims using all of these options.
 
+== Configuration
+=== Smallrye JWT properties
+
+Smallrye JWT supports many properties which can be used to customize the token processing:
+
+[cols="<m,<m,<2",options="header"]
+|===
+|Property Name|Default|Description
+|smallrye.jwt.encrypt.key-location|none|Config property allows the location of a key to be specified which will be used to encrypt the claims or inner JWT.
+|smallrye.jwt.sign.key-location|none|Config property allows the location of a private key to be specified which will be used to sign the claims of a JWT.
+|===
+
 == Create JwtClaimsBuilder and set the claims
 
 The first step is to initialize a `JwtClaimsBuilder` using one of the options below and add some claims to it:

--- a/doc/modules/ROOT/pages/generate-jwt.adoc
+++ b/doc/modules/ROOT/pages/generate-jwt.adoc
@@ -15,18 +15,6 @@ encrypting the nested JWT token.
 
 SmallRye JWT provides an API for securing the JWT claims using all of these options.
 
-== Configuration
-=== Smallrye JWT properties
-
-Smallrye JWT supports the following properties which can be used to customize the way claims are signed and encrypted:
-
-[cols="<m,<m,<2",options="header"]
-|===
-|Property Name|Default|Description
-|smallrye.jwt.encrypt.key-location|none|Config property allows the location of a key to be specified which will be used to encrypt the claims or inner JWT.
-|smallrye.jwt.sign.key-location|none|Config property allows the location of a private key to be specified which will be used to sign the claims of a JWT.
-|===
-
 == Create JwtClaimsBuilder and set the claims
 
 The first step is to initialize a `JwtClaimsBuilder` using one of the options below and add some claims to it:
@@ -106,3 +94,14 @@ import io.smallrye.jwt.build.Jwt;
 // Sign the claims and encrypt the nested token using the private and public keys loaded from the locations set with the 'smallrye.jwt.sign.key-location' and 'smallrye.jwt.encrypt.key-location' properties respectively.
 String jwt = Jwt.claims("/tokenClaims.json").innerSign().encrypt();
 ----
+
+== Configuration
+
+Smallrye JWT supports the following properties which can be used to customize the way claims are signed and encrypted:
+
+[cols="<m,<m,<2",options="header"]
+|===
+|Property Name|Default|Description
+|smallrye.jwt.encrypt.key-location|none|Config property allows the location of a key to be specified which will be used to encrypt the claims or inner JWT.
+|smallrye.jwt.sign.key-location|none|Config property allows the location of a private key to be specified which will be used to sign the claims of a JWT.
+|===


### PR DESCRIPTION
Added documentation for the encrypt and sign key locations.

https://github.com/smallrye/smallrye-jwt/issues/221