### PR TITLE
Add a method to init JwtClaimsBuilder from JsonWebToken

### DIFF
--- a/implementation/src/main/java/io/smallrye/jwt/build/Jwt.java
+++ b/implementation/src/main/java/io/smallrye/jwt/build/Jwt.java
@@ -6,6 +6,8 @@ import java.util.Map;
 import javax.json.JsonArray;
 import javax.json.JsonObject;
 
+import org.eclipse.microprofile.jwt.JsonWebToken;
+
 import io.smallrye.jwt.build.spi.JwtProvider;
 
 /**
@@ -54,7 +56,7 @@ public final class Jwt {
 
     /**
      * Creates a new instance of {@link JwtClaimsBuilder} from a map of claims.
-     * 
+     *
      * @param claims the map with the claim name and value pairs. Claim value is converted to String unless it is
      *        an instance of {@link Boolean}, {@link Number}, {@link Collection}, {@link Map},
      *        {@link JsonObject} or {@link JsonArray}.
@@ -66,11 +68,21 @@ public final class Jwt {
 
     /**
      * Creates a new instance of {@link JwtClaimsBuilder} from a JSON resource.
-     * 
+     *
      * @param jsonLocation JSON resource location
      * @return {@link JwtClaimsBuilder}
      */
     public static JwtClaimsBuilder claims(String jsonLocation) {
         return JwtProvider.provider().claims(jsonLocation);
+    }
+
+    /**
+     * Creates a new instance of {@link JwtClaimsBuilder} from {@link JsonWebToken}.
+     *
+     * @param jwt JsonWebToken token.
+     * @return {@link JwtClaimsBuilder}
+     */
+    public static JwtClaimsBuilder claims(JsonWebToken jwt) {
+        return JwtProvider.provider().claims(jwt);
     }
 }

--- a/implementation/src/main/java/io/smallrye/jwt/build/impl/JwtProviderImpl.java
+++ b/implementation/src/main/java/io/smallrye/jwt/build/impl/JwtProviderImpl.java
@@ -1,6 +1,10 @@
 package io.smallrye.jwt.build.impl;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
+
+import org.eclipse.microprofile.jwt.Claims;
+import org.eclipse.microprofile.jwt.JsonWebToken;
 
 import io.smallrye.jwt.build.JwtClaimsBuilder;
 import io.smallrye.jwt.build.spi.JwtProvider;
@@ -33,6 +37,21 @@ public class JwtProviderImpl extends JwtProvider {
     @Override
     public JwtClaimsBuilder claims(String jsonLocation) {
         return new JwtClaimsBuilderImpl(jsonLocation);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public JwtClaimsBuilder claims(JsonWebToken jwt) {
+        Map<String, Object> claims = new LinkedHashMap<>();
+        for (String name : jwt.getClaimNames()) {
+            if (Claims.raw_token.name().equals(name)) {
+                continue;
+            }
+            claims.put(name, jwt.getClaim(name));
+        }
+        return claims(claims);
     }
 
 }

--- a/implementation/src/main/java/io/smallrye/jwt/build/spi/JwtProvider.java
+++ b/implementation/src/main/java/io/smallrye/jwt/build/spi/JwtProvider.java
@@ -8,6 +8,8 @@ import java.util.ServiceLoader;
 import javax.json.JsonArray;
 import javax.json.JsonObject;
 
+import org.eclipse.microprofile.jwt.JsonWebToken;
+
 import io.smallrye.jwt.build.JwtClaimsBuilder;
 import io.smallrye.jwt.build.JwtException;
 
@@ -56,7 +58,7 @@ public abstract class JwtProvider {
 
     /**
      * Creates a new instance of {@link JwtClaimsBuilder}
-     * 
+     *
      * @return {@link JwtClaimsBuilder}
      */
     public abstract JwtClaimsBuilder claims();
@@ -73,10 +75,18 @@ public abstract class JwtProvider {
 
     /**
      * Creates a new instance of {@link JwtClaimsBuilder} from a JSON resource.
-     * 
+     *
      * @param jsonLocation JSON resource location
      * @return {@link JwtClaimsBuilder}
      */
     public abstract JwtClaimsBuilder claims(String jsonLocation);
+
+    /**
+     * Creates a new instance of {@link JwtClaimsBuilder} from {@link JsonWebToken}.
+     *
+     * @param jwt JsonWebToken token.
+     * @return {@link JwtClaimsBuilder}
+     */
+    public abstract JwtClaimsBuilder claims(JsonWebToken jwt);
 
 }


### PR DESCRIPTION
To support a Quarkus user who needs to enhance an injected or parsed token. This method is a thin wrapper around a method accepting a Map of claims