### PR TITLE
Fix testsuite and doc links in readme

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -73,8 +73,10 @@ mvn clean install
 === Project structure
 
 * link:implementation[] - Implementation of the {mp-jwt-name} library.
-* link:tck[] - Test suite to run the implementation against the {mp-jwt-name} TCK.
-* link:docs[] - Project documentation.
+* link:testsuite[] - Test suites
+** link:testsuite/basic[] Test suite with basic test cases.
+** link:testsuite/tck[] Test suite to run the implementation against the {mp-jwt-name} TCK.
+* link:doc[] - Project documentation.
 
 === Links
 


### PR DESCRIPTION
Testsuite and documentation link seem to be outdated and don't work any more. I updated them to the new locations and added a link for the testsuite/baisc.