### PR TITLE
Support Quarkus Dev mode with the context without the keys

### DIFF
--- a/testsuite/basic/src/test/java/io/smallrye/jwt/auth/principal/KeyLocationResolverTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/jwt/auth/principal/KeyLocationResolverTest.java
@@ -100,6 +100,20 @@ public class KeyLocationResolverTest {
     }
 
     @Test
+    public void testVerifyWithoutPrivateKey() throws Exception {
+        PrivateKey privateKey = TokenUtils.readPrivateKey("/privateKey.pem");
+        String token = TokenUtils.generateTokenString(privateKey, "1", "/Token1.json", null, null);
+        JWTAuthContextInfoProvider provider = JWTAuthContextInfoProvider.createWithKeyLocation("NONE",
+                "https://server.example.com");
+        try {
+            Assert.assertNotNull(new DefaultJWTTokenParser().parse(token, provider.getContextInfo()));
+            Assert.fail("UnresolvableKeyException is expected");
+        } catch (ParseException ex) {
+            Assert.assertTrue(ex.getCause() instanceof UnresolvableKeyException);
+        }
+    }
+
+    @Test
     public void testVerifyWithFileSystemPemKey2() throws Exception {
         verifyToken("key3", null, "file:target/test-classes/publicKey.pem");
     }

--- a/testsuite/basic/src/test/java/io/smallrye/jwt/config/JWTAuthContextInfoProviderTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/jwt/config/JWTAuthContextInfoProviderTest.java
@@ -41,13 +41,13 @@ public class JWTAuthContextInfoProviderTest {
         JWTAuthContextInfoProvider provider = JWTAuthContextInfoProvider.createWithKeyLocation("NONE", TEST_ISS);
         Optional<JWTAuthContextInfo> info = provider.getOptionalContextInfo();
         assertNotNull(info);
-        assertTrue(!info.isPresent());
+        assertTrue(info.isPresent());
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testDefaultGetContextInfo() {
         JWTAuthContextInfoProvider provider = JWTAuthContextInfoProvider.createWithKeyLocation("NONE", TEST_ISS);
-        provider.getContextInfo();
+        assertNotNull(provider.getContextInfo());
     }
 
     @Test


### PR DESCRIPTION
We've had numerous Quarkus related feedback in that throwing the exception if no public key location is available at the CDI Producer method time affects the developer experience badly, the latest feedback is [here](https://github.com/quarkusio/quarkus/issues/5211#issuecomment-589952165).
This PR does not change anything fundamentally, right now `KeyLocationResolver` is a central place where the keys are resolved anyway, the process which fails if the location is invalid, so if location is not set or the key is not inlined, then the same `UnresolvableKeyException` is thrown.

Note I may need to revisit the whole idea of loading the key content in `KeyLocationResolver` and try to at least pre-load it for the local resources in the producer. Https resources are trickier to preload reliably as we've had the cases in Quarkus where the OIDC server is a few seconds behind. But I'll deal with it separately. There will be some best effort to ensure early that the location exists.

Here is a [Quarkus dev test](https://github.com/sberyozkin/quarkus/commit/4fc4a453037ae3ddf27e3370f9485486b49d7f57) on my branch against this PR:
- the user has a smallrye-jwt extension without any configuration
- then in the dev mode they add the properties (in the test this is achieved by removing `#` comments)
- all starts working
