### PR TITLE
Support for creating tokens from JsonObject

### DIFF
--- a/implementation/src/main/java/io/smallrye/jwt/build/Jwt.java
+++ b/implementation/src/main/java/io/smallrye/jwt/build/Jwt.java
@@ -67,6 +67,16 @@ public final class Jwt {
     }
 
     /**
+     * Creates a new instance of {@link JwtClaimsBuilder} from {@link JsonObject}
+     *
+     * @param jsonObject {@link JsonObject} containing the claims.
+     * @return {@link JwtClaimsBuilder}
+     */
+    public static JwtClaimsBuilder claims(JsonObject jsonObject) {
+        return JwtProvider.provider().claims(jsonObject);
+    }
+
+    /**
      * Creates a new instance of {@link JwtClaimsBuilder} from a JSON resource.
      *
      * @param jsonLocation JSON resource location

--- a/implementation/src/main/java/io/smallrye/jwt/build/impl/JwtProviderImpl.java
+++ b/implementation/src/main/java/io/smallrye/jwt/build/impl/JwtProviderImpl.java
@@ -3,6 +3,9 @@ package io.smallrye.jwt.build.impl;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import javax.json.JsonObject;
+import javax.json.JsonValue;
+
 import org.eclipse.microprofile.jwt.Claims;
 import org.eclipse.microprofile.jwt.JsonWebToken;
 
@@ -29,6 +32,17 @@ public class JwtProviderImpl extends JwtProvider {
     @Override
     public JwtClaimsBuilder claims(Map<String, Object> claims) {
         return new JwtClaimsBuilderImpl(claims);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public JwtClaimsBuilder claims(JsonObject jsonObject) {
+        Map<String, Object> claims = new LinkedHashMap<>();
+        for (Map.Entry<String, JsonValue> entry : jsonObject.entrySet()) {
+            claims.put(entry.getKey(), entry.getValue());
+        }
+        return claims(claims);
     }
 
     /**

--- a/implementation/src/main/java/io/smallrye/jwt/build/spi/JwtProvider.java
+++ b/implementation/src/main/java/io/smallrye/jwt/build/spi/JwtProvider.java
@@ -74,6 +74,14 @@ public abstract class JwtProvider {
     public abstract JwtClaimsBuilder claims(Map<String, Object> claims);
 
     /**
+     * Creates a new instance of {@link JwtClaimsBuilder} from {@link JsonObject}
+     *
+     * @param jsonObject {@link JsonObject} containing the claims.
+     * @return {@link JwtClaimsBuilder}
+     */
+    public abstract JwtClaimsBuilder claims(JsonObject jsonObject);
+
+    /**
      * Creates a new instance of {@link JwtClaimsBuilder} from a JSON resource.
      *
      * @param jsonLocation JSON resource location

--- a/implementation/src/test/java/io/smallrye/jwt/build/JwtSignTest.java
+++ b/implementation/src/test/java/io/smallrye/jwt/build/JwtSignTest.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 import javax.crypto.SecretKey;
 import javax.json.Json;
+import javax.json.JsonObject;
 
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.spi.ConfigSource;
@@ -110,6 +111,27 @@ public class JwtSignTest {
         checkDefaultClaimsAndHeaders(getJwsHeaders(jwt, 2), claims);
 
         Assert.assertEquals("custom-value", claims.getClaimValue("customClaim"));
+    }
+
+    @Test
+    public void testSignJsonObject() throws Exception {
+        JsonObject userName = Json.createObjectBuilder().add("username", "Alice").build();
+        JsonObject userAddress = Json.createObjectBuilder().add("city", "someCity").add("street", "someStreet").build();
+        JsonObject json = Json.createObjectBuilder(userName).add("address", userAddress).build();
+        String jwt = Jwt.claims(json).sign("/privateKey.pem");
+
+        JsonWebSignature jws = getVerifiedJws(jwt);
+        JwtClaims claims = JwtClaims.parse(jws.getPayload());
+
+        Assert.assertEquals(5, claims.getClaimsMap().size());
+        checkDefaultClaimsAndHeaders(getJwsHeaders(jwt, 2), claims);
+
+        Assert.assertEquals("Alice", claims.getClaimValue("username"));
+        @SuppressWarnings("unchecked")
+        Map<String, String> address = (Map<String, String>) claims.getClaimValue("address");
+        Assert.assertEquals(2, address.size());
+        Assert.assertEquals("someCity", address.get("city"));
+        Assert.assertEquals("someStreet", address.get("street"));
     }
 
     @Test


### PR DESCRIPTION
This PR supports a case where a JSON is already available, example, read from DB etc. It will make it even simpler to turn any custom JSON into custom JWT claims. 
Next I'll add more configuration properties so that 'technical'/standard claims like `issuer` and `exp` or headers like `kid` can be configured plus a set of shortcuts like `Jwt.sign(jsonObject)`