### PR TITLE
Throw NotAuthorizedException if a JWT is sent to an unauthenticated endpoint and is not valid

### DIFF
--- a/implementation/src/main/java/io/smallrye/jwt/auth/jaxrs/JAXRSLogging.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/jaxrs/JAXRSLogging.java
@@ -30,4 +30,8 @@ interface JAXRSLogging extends BasicLogger {
     @LogMessage(level = Logger.Level.INFO)
     @Message(id = 10004, value = "LoginConfig not found on Application class, %s will not be enabled")
     void mpJWTLoginConfigNotFound(String className);
+
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 10005, value = "An invalid JWT was sent to an unauthenticated endpoint")
+    void invalidJWTSentToUnauthenticatedEndpoint();
 }

--- a/implementation/src/main/java/io/smallrye/jwt/auth/jaxrs/JWTAuthenticationFilter.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/jaxrs/JWTAuthenticationFilter.java
@@ -21,11 +21,13 @@ import java.security.Principal;
 
 import javax.annotation.Priority;
 import javax.inject.Inject;
+import javax.ws.rs.NotAuthorizedException;
 import javax.ws.rs.Priorities;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.PreMatching;
 import javax.ws.rs.core.Cookie;
+import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 
 import org.eclipse.microprofile.jwt.JsonWebToken;
@@ -41,13 +43,12 @@ import io.smallrye.jwt.auth.principal.JWTParser;
 @PreMatching
 @Priority(Priorities.AUTHENTICATION)
 public class JWTAuthenticationFilter implements ContainerRequestFilter {
+    public static final String HAS_JWT = JWTAuthenticationFilter.class.getName() + ".has.jwt";
 
     @Inject
     private JWTAuthContextInfo authContextInfo;
-
     @Inject
     private JWTParser jwtParser;
-
     @Inject
     private PrincipalProducer producer;
 
@@ -71,6 +72,7 @@ public class JWTAuthenticationFilter implements ContainerRequestFilter {
                     JAXRSLogging.log.success();
                 } catch (Exception e) {
                     JAXRSLogging.log.unableParseJWT(e);
+                    throw new NotAuthorizedException(Response.status(Response.Status.UNAUTHORIZED).build());
                 }
             }
         }

--- a/testsuite/tck/src/test/resources/tck-base-suite.xml
+++ b/testsuite/tck/src/test/resources/tck-base-suite.xml
@@ -77,7 +77,7 @@
       <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.CookieTokenTest" />
       <class name="org.eclipse.microprofile.jwt.tck.config.TokenAsCookieIgnoredTest" />
       <class name="org.eclipse.microprofile.jwt.tck.config.TokenAsCookieTest" />
-      <!--<class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.EmptyTokenTest" />-->
+      <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.EmptyTokenTest" />
       <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedEncryptTest" />
       <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" />
       <class name="org.eclipse.microprofile.jwt.tck.config.jwe.PrivateKeyAsPEMClasspathTest" />


### PR DESCRIPTION
To fix TCK test EmptyTokenTest in MP 1.2.