### PR TITLE
Minor JWT build improvements

### DIFF
--- a/doc/modules/ROOT/pages/generate-jwt.adoc
+++ b/doc/modules/ROOT/pages/generate-jwt.adoc
@@ -34,11 +34,21 @@ JwtClaimsBuilder builder2 = Jwt.claims("/tokenClaims.json");
 
 // Builder created from a map of claims
 JwtClaimsBuilder builder3 = Jwt.claims(Collections.singletonMap("customClaim", "custom-value"));
+
+// Builder created from JsonObject
+JsonObject userName = Json.createObjectBuilder().add("username", "Alice").build();
+JsonObject userAddress = Json.createObjectBuilder().add("city", "someCity").add("street", "someStreet").build();
+JsonObject json = Json.createObjectBuilder(userName).add("address", userAddress).build();
+JwtClaimsBuilder builder4 = Jwt.claims(json);
+
+// Builder created from JsonWebToken
+@Inject JsonWebToken token;
+JwtClaimsBuilder builder5 = Jwt.claims(token);
 ----
 
 The API is fluent so the builder initialization can be done as part of the fluent API sequence. The builder will also
-set `iat (issued at) to the current time, `exp`(expires at) to 5 minutes away from the current time and `jti`
-(unique token identifier) claims if they have not already been set, so one can skip setting them when possible.
+set `iat (issued at) claim to the current time, `exp`(expires at) claim to a sum of the `iat` claim and `smallrye.jwt.new-token.lifespan`
+property values and `jti` (unique token identifier) claim if they have not already been set, so one can skip setting them when possible.
 
 The next step is to decide how to secure the claims.
 
@@ -56,7 +66,7 @@ import io.smallrye.jwt.build.Jwt;
 String jwt1 = Jwt.claims("/tokenClaims.json").sign();
 
 // Set the headers and sign the claims with an RSA private key loaded in the code (the implementation of this method is omitted). Note a 'jws()' transition to a 'JwtSignatureBuilder'.
-String jwt2 = Jwt.claims("/tokenClaims.json").jws().signatureKeyId("kid1").header("custom-header", "custom-value").sign(getPrivateKey());
+String jwt2 = Jwt.claims("/tokenClaims.json").jws().keyId("kid1").header("custom-header", "custom-value").sign(getPrivateKey());
 ----
 
 Note the `alg` (algorithm) header is set to `RS256` by default.
@@ -102,6 +112,8 @@ Smallrye JWT supports the following properties which can be used to customize th
 [cols="<m,<m,<2",options="header"]
 |===
 |Property Name|Default|Description
-|smallrye.jwt.encrypt.key-location|none|Config property allows the location of a key to be specified which will be used to encrypt the claims or inner JWT.
-|smallrye.jwt.sign.key-location|none|Config property allows the location of a private key to be specified which will be used to sign the claims of a JWT.
+|smallrye.jwt.encrypt.key-location|none|Location of a key which will be used to encrypt the claims or inner JWT when a no-argument encrypt() method is called.
+|smallrye.jwt.sign.key-location|none|Location of a key which will be used to sign the claims when either a no-argument sign() or innerSign() method is called.
+|smallrye.jwt.new-token.lifespan|300|Token lifespan in seconds which will be used to calculate an `exp` (expiry) claim value if this claim has not already been set.
+|smallrye.jwt.new-token.issuer|none|Token issuer which can be used to set an `iss` (issuer) claim value if this claim has not already been set.
 |===

--- a/implementation/src/main/java/io/smallrye/jwt/build/JwtClaimsBuilder.java
+++ b/implementation/src/main/java/io/smallrye/jwt/build/JwtClaimsBuilder.java
@@ -14,6 +14,13 @@ import javax.json.JsonObject;
  * JwtClaimsBuilder implementations must set the 'iat' (issued at time), 'exp' (expiration time)
  * and 'jit' (unique token identifier) claims unless they have already been set.
  * <p>
+ * By default the 'iat' claim is set to the current time in seconds and the 'exp' claim is set by adding a default token
+ * lifespan value of 5 minutes to the 'iat' claim value. The 'smallrye.jwt.new-token.lifespan' property can be used to
+ * customize a new token lifespan and its 'exp' claim values.
+ * <p>
+ * JwtClaimsBuilder implementations must set the 'iss' (issuer) claim if has not already been set and
+ * the 'smallrye.jwt.new-token.issuer' property is set.
+ * <p>
  * Note that JwtClaimsBuilder implementations are not expected to be thread-safe.
  * 
  * @see <a href="https://tools.ietf.org/html/rfc7519">RFC7515</a>
@@ -63,7 +70,7 @@ public interface JwtClaimsBuilder extends JwtSignature {
     /**
      * Set an expiry 'exp' claim
      * 
-     * @param expiredAt the expiry time
+     * @param expiredAt the expiry time in seconds
      * @return JwtClaimsBuilder
      */
     JwtClaimsBuilder expiresAt(long expiredAt);

--- a/implementation/src/main/java/io/smallrye/jwt/build/JwtEncryptionBuilder.java
+++ b/implementation/src/main/java/io/smallrye/jwt/build/JwtEncryptionBuilder.java
@@ -22,27 +22,75 @@ public interface JwtEncryptionBuilder extends JwtEncryption {
      * Note that only 'RSA-OAEP-256' (default), 'ECDH-ES+A256KW' and 'A256KW' algorithms must be supported.
      * A key of size 2048 bits or larger MUST be used with 'RSA-OAEP-256' algorithm.
      * 
+     * @since 2.1.3
+     *
      * @param algorithm the key encryption algorithm
      * @return JwtEncryptionBuilder
      */
-    JwtEncryptionBuilder keyEncryptionAlgorithm(KeyEncryptionAlgorithm algorithm);
+    JwtEncryptionBuilder keyAlgorithm(KeyEncryptionAlgorithm algorithm);
+
+    /**
+     * Set an 'alg' key encryption algorithm.
+     * Note that only 'RSA-OAEP-256' (default), 'ECDH-ES+A256KW' and 'A256KW' algorithms must be supported.
+     * A key of size 2048 bits or larger MUST be used with 'RSA-OAEP-256' algorithm.
+     *
+     * @deprecated Use {@link #keyAlgorithm}
+     *
+     * @param algorithm the key encryption algorithm
+     * @return JwtEncryptionBuilder
+     */
+    @Deprecated
+    default JwtEncryptionBuilder keyEncryptionAlgorithm(KeyEncryptionAlgorithm algorithm) {
+        return keyAlgorithm(algorithm);
+    }
 
     /**
      * Set an 'enc' content encryption algorithm.
      * Note that only 'A256GCM' (default) and 'A128CBC-HS256' algorithms must be supported.
+     *
+     * @since 2.1.3
+     *
+     * @param algorithm the content encryption algorithm
+     * @return JwtEncryptionBuilder
+     */
+    JwtEncryptionBuilder contentAlgorithm(ContentEncryptionAlgorithm algorithm);
+
+    /**
+     * Set an 'enc' content encryption algorithm.
+     * Note that only 'A256GCM' (default) and 'A128CBC-HS256' algorithms must be supported.
+     *
+     * @deprecated Use {@link #contentAlgorithm}
      * 
      * @param algorithm the content encryption algorithm
      * @return JwtEncryptionBuilder
      */
-    JwtEncryptionBuilder contentEncryptionAlgorithm(ContentEncryptionAlgorithm algorithm);
+    @Deprecated
+    default JwtEncryptionBuilder contentEncryptionAlgorithm(ContentEncryptionAlgorithm algorithm) {
+        return contentAlgorithm(algorithm);
+    }
 
     /**
      * Set a 'kid' key encryption key id.
+     *
+     * @since 2.1.3
+     *
+     * @param keyId the key id
+     * @return JwtEncryptionBuilder
+     */
+    JwtEncryptionBuilder keyId(String keyId);
+
+    /**
+     * Set a 'kid' key encryption key id.
+     *
+     * @deprecated Use {@link #keyId}
      * 
      * @param keyId the key id
      * @return JwtEncryptionBuilder
      */
-    JwtEncryptionBuilder keyEncryptionKeyId(String keyId);
+    @Deprecated
+    default JwtEncryptionBuilder keyEncryptionKeyId(String keyId) {
+        return keyId(keyId);
+    }
 
     /**
      * Custom JWT encryption header.

--- a/implementation/src/main/java/io/smallrye/jwt/build/JwtSignatureBuilder.java
+++ b/implementation/src/main/java/io/smallrye/jwt/build/JwtSignatureBuilder.java
@@ -22,19 +22,50 @@ public interface JwtSignatureBuilder extends JwtSignature {
     /**
      * Set a signature algorithm.
      * Note that only 'RS256' (default), 'ES256' and 'HS256' algorithms must be supported.
+     *
+     * @since 2.1.3
+     *
+     * @param algorithm the signature algorithm
+     * @return JwtSignatureBuilder
+     */
+    JwtSignatureBuilder algorithm(SignatureAlgorithm algorithm);
+
+    /**
+     * Set a signature algorithm.
+     * Note that only 'RS256' (default), 'ES256' and 'HS256' algorithms must be supported.
+     *
+     * @deprecated Use {@link #algorithm}
      * 
      * @param algorithm the signature algorithm
      * @return JwtSignatureBuilder
      */
-    JwtSignatureBuilder signatureAlgorithm(SignatureAlgorithm algorithm);
+    @Deprecated
+    default JwtSignatureBuilder signatureAlgorithm(SignatureAlgorithm algorithm) {
+        return algorithm(algorithm);
+    }
 
     /**
-     * Set a 'kid' signature key id
-     * 
+     * Set a 'kid' signature key id.
+     *
+     * @since 2.1.3
+     *
      * @param keyId the key id
      * @return JwtSignatureBuilder
      */
-    JwtSignatureBuilder signatureKeyId(String keyId);
+    JwtSignatureBuilder keyId(String keyId);
+
+    /**
+     * Set a 'kid' signature key id.
+     *
+     * @deprecated Use {@link #keyId}
+     *
+     * @param keyId the key id
+     * @return JwtSignatureBuilder
+     */
+    @Deprecated
+    default JwtSignatureBuilder signatureKeyId(String keyId) {
+        return keyId(keyId);
+    }
 
     /**
      * Custom JWT signature header.
@@ -72,6 +103,8 @@ public interface JwtSignatureBuilder extends JwtSignature {
      * 
      * If no "smallrye.jwt.sign.key-location" property is set then an insecure inner JWT with a "none" algorithm
      * has to be created before being encrypted.
+     *
+     * Note: Support for the 'none' algorithm is deprecated.
      * 
      * @return JwtEncryptionBuilder
      * @throws JwtSignatureException the exception if the inner JWT signing operation has failed

--- a/implementation/src/main/java/io/smallrye/jwt/build/impl/JwtClaimsBuilderImpl.java
+++ b/implementation/src/main/java/io/smallrye/jwt/build/impl/JwtClaimsBuilderImpl.java
@@ -162,7 +162,7 @@ class JwtClaimsBuilderImpl extends JwtSignatureImpl implements JwtClaimsBuilder,
     @Override
     public JwtSignatureBuilder header(String name, Object value) {
         if ("alg".equals(name)) {
-            return signatureAlgorithm(toSignatureAlgorithm((String) value));
+            return algorithm(toSignatureAlgorithm((String) value));
         } else {
             headers.put(name, value);
             return this;
@@ -173,7 +173,7 @@ class JwtClaimsBuilderImpl extends JwtSignatureImpl implements JwtClaimsBuilder,
      * {@inheritDoc}
      */
     @Override
-    public JwtSignatureBuilder signatureAlgorithm(SignatureAlgorithm algorithm) {
+    public JwtSignatureBuilder algorithm(SignatureAlgorithm algorithm) {
         headers.put("alg", algorithm.name());
         return this;
     }
@@ -182,7 +182,7 @@ class JwtClaimsBuilderImpl extends JwtSignatureImpl implements JwtClaimsBuilder,
      * {@inheritDoc}
      */
     @Override
-    public JwtSignatureBuilder signatureKeyId(String keyId) {
+    public JwtSignatureBuilder keyId(String keyId) {
         headers.put("kid", keyId);
         return this;
     }

--- a/implementation/src/main/java/io/smallrye/jwt/build/impl/JwtEncryptionImpl.java
+++ b/implementation/src/main/java/io/smallrye/jwt/build/impl/JwtEncryptionImpl.java
@@ -81,9 +81,9 @@ class JwtEncryptionImpl implements JwtEncryptionBuilder {
     @Override
     public JwtEncryptionBuilder header(String name, Object value) {
         if ("alg".equals(name)) {
-            return keyEncryptionAlgorithm(toKeyEncryptionAlgorithm((String) value));
+            return keyAlgorithm(toKeyEncryptionAlgorithm((String) value));
         } else if ("enc".equals(name)) {
-            return contentEncryptionAlgorithm(toContentEncryptionAlgorithm((String) value));
+            return contentAlgorithm(toContentEncryptionAlgorithm((String) value));
         } else {
             headers.put(name, value);
             return this;
@@ -94,7 +94,7 @@ class JwtEncryptionImpl implements JwtEncryptionBuilder {
      * {@inheritDoc}
      */
     @Override
-    public JwtEncryptionBuilder keyEncryptionAlgorithm(KeyEncryptionAlgorithm algorithm) {
+    public JwtEncryptionBuilder keyAlgorithm(KeyEncryptionAlgorithm algorithm) {
         headers.put("alg", algorithm.getAlgorithm());
         return this;
     }
@@ -103,7 +103,7 @@ class JwtEncryptionImpl implements JwtEncryptionBuilder {
      * {@inheritDoc}
      */
     @Override
-    public JwtEncryptionBuilder contentEncryptionAlgorithm(ContentEncryptionAlgorithm algorithm) {
+    public JwtEncryptionBuilder contentAlgorithm(ContentEncryptionAlgorithm algorithm) {
         headers.put("enc", algorithm.getAlgorithm());
         return this;
     }
@@ -112,7 +112,7 @@ class JwtEncryptionImpl implements JwtEncryptionBuilder {
      * {@inheritDoc}
      */
     @Override
-    public JwtEncryptionBuilder keyEncryptionKeyId(String keyId) {
+    public JwtEncryptionBuilder keyId(String keyId) {
         headers.put("kid", keyId);
         return this;
     }

--- a/implementation/src/test/java/io/smallrye/jwt/build/JwtBuildConfigSource.java
+++ b/implementation/src/test/java/io/smallrye/jwt/build/JwtBuildConfigSource.java
@@ -8,6 +8,8 @@ import org.eclipse.microprofile.config.spi.ConfigSource;
 public class JwtBuildConfigSource implements ConfigSource {
 
     boolean signingKeyAvailable = true;
+    boolean lifespanPropertyRequired;
+    boolean issuerPropertyRequired;
     String encryptionKeyLocation = "/publicKey.pem";
     String signingKeyLocation = "/privateKey.pem";
 
@@ -18,6 +20,12 @@ public class JwtBuildConfigSource implements ConfigSource {
             map.put("smallrye.jwt.sign.key-location", signingKeyLocation);
         }
         map.put("smallrye.jwt.encrypt.key-location", encryptionKeyLocation);
+        if (lifespanPropertyRequired) {
+            map.put("smallrye.jwt.new-token.lifespan", "2000");
+        }
+        if (issuerPropertyRequired) {
+            map.put("smallrye.jwt.new-token.issuer", "https://custom-issuer");
+        }
         return map;
     }
 
@@ -41,5 +49,13 @@ public class JwtBuildConfigSource implements ConfigSource {
 
     public void setSigningKeyLocation(String location) {
         this.signingKeyLocation = location;
+    }
+
+    void setLifespanPropertyRequired(boolean lifespanPropertyRequired) {
+        this.lifespanPropertyRequired = lifespanPropertyRequired;
+    }
+
+    public void setIssuerPropertyRequired(boolean issuerPropertyRequired) {
+        this.issuerPropertyRequired = issuerPropertyRequired;
     }
 }

--- a/implementation/src/test/java/io/smallrye/jwt/build/JwtEncryptTest.java
+++ b/implementation/src/test/java/io/smallrye/jwt/build/JwtEncryptTest.java
@@ -45,7 +45,7 @@ public class JwtEncryptTest {
         String jweCompact = Jwt.claims()
                 .claim("customClaim", "custom-value")
                 .jwe()
-                .keyEncryptionKeyId("key-enc-key-id")
+                .keyId("key-enc-key-id")
                 .encrypt();
 
         checkJweHeaders(jweCompact);
@@ -61,7 +61,7 @@ public class JwtEncryptTest {
         String jweCompact = Jwt.claims()
                 .claim("customClaim", "custom-value")
                 .jwe()
-                .keyEncryptionKeyId("key-enc-key-id")
+                .keyId("key-enc-key-id")
                 .encrypt("publicKey.pem");
 
         checkJweHeaders(jweCompact);
@@ -92,7 +92,7 @@ public class JwtEncryptTest {
         String jweCompact = Jwt.claims()
                 .claim("customClaim", "custom-value")
                 .jwe()
-                .keyEncryptionKeyId("key-enc-key-id")
+                .keyId("key-enc-key-id")
                 .encrypt(jwk.getECPublicKey());
 
         checkJweHeaders(jweCompact, "ECDH-ES+A256KW", 4);
@@ -109,8 +109,8 @@ public class JwtEncryptTest {
         String jweCompact = Jwt.claims()
                 .claim("customClaim", "custom-value")
                 .jwe()
-                .keyEncryptionKeyId("key-enc-key-id")
-                .contentEncryptionAlgorithm(ContentEncryptionAlgorithm.A128CBC_HS256)
+                .keyId("key-enc-key-id")
+                .contentAlgorithm(ContentEncryptionAlgorithm.A128CBC_HS256)
                 .encrypt(jwk.getECPublicKey());
 
         checkJweHeaders(jweCompact, "ECDH-ES+A256KW", "A128CBC-HS256", 4);
@@ -126,7 +126,7 @@ public class JwtEncryptTest {
         String jweCompact = Jwt.claims()
                 .claim("customClaim", "custom-value")
                 .jwe()
-                .keyEncryptionKeyId("key-enc-key-id")
+                .keyId("key-enc-key-id")
                 .encrypt(createSecretKey());
 
         checkJweHeaders(jweCompact, "A256KW", 3);

--- a/implementation/src/test/java/io/smallrye/jwt/build/JwtSignEncryptTest.java
+++ b/implementation/src/test/java/io/smallrye/jwt/build/JwtSignEncryptTest.java
@@ -63,9 +63,9 @@ public class JwtSignEncryptTest {
         String jweCompact = Jwt.claims()
                 .claim("customClaim", "custom-value")
                 .jws()
-                .signatureKeyId("sign-key-id")
+                .keyId("sign-key-id")
                 .innerSign()
-                .keyEncryptionKeyId("key-enc-key-id")
+                .keyId("key-enc-key-id")
                 .encrypt();
 
         checkJweHeaders(jweCompact, "RSA-OAEP-256", "key-enc-key-id");
@@ -93,7 +93,7 @@ public class JwtSignEncryptTest {
                     .claim("customClaim", "custom-value")
                     .jws()
                     .innerSign()
-                    .keyEncryptionKeyId("key-enc-key-id")
+                    .keyId("key-enc-key-id")
                     .encrypt();
         } finally {
             configSource.setSigningKeyAvailability(true);
@@ -123,9 +123,9 @@ public class JwtSignEncryptTest {
             jweCompact = Jwt.claims()
                     .claim("customClaim", "custom-value")
                     .jws()
-                    .signatureKeyId("sign-key-id")
+                    .keyId("sign-key-id")
                     .innerSign()
-                    .keyEncryptionKeyId("key1")
+                    .keyId("key1")
                     .encrypt();
         } finally {
             configSource.setEncryptionKeyLocation("/publicKey.pem");


### PR DESCRIPTION
This PR:
* Deprecates a number of builder API methods and introduces more compact alternatives.

  For example, when we do:
  `Jwt.claims("somejson.json").jws().signatureKeyId("kid").sign()`, `signature` in `signatureKeyId` is duplicating what both `jws()` and `sign` imply. Similarly for all other deprecated methods. The IDE also helps with algorithm related methods, for ex, when we do `jws().algorithm(...)` we see a `SignatureAlgorithm` parameter type.

  In fact, originally I did plan for `Jwt.claims("somejson.json").jws().keyId("kid").sign()` - the compactness of the API is a big priority, but then I somehow got offtrack when I was looking at the inner token case, where the token is signed and encrypted:
```
Jwt.claims().jws().keyId().innerSign().keyId().encrypt();
```
Here I thought well, 2 `keyId()`, 1st one sets a key if of the signing key, 2nd one - of the key encryption key.
But over time I've come to the conclusion that this case is quite advanced, the mainstream case is `sign` and in this advanced case, after the formatting, it also becomes more readable. `kid`s will likely be configurable too.
* deprecated `none` for the `innerSign()` - I came to this conclusion while doing the initial MP JWT PR, it is basically useless :-) to have encrypt() with an internal `none` as it does not add anything to the `encrypt` only case, i.e, it does not help with identifying who signed it. It also makes it hard to spot if the user made a typo in the config property

All of these deprecated methods/properties will be dropped in 3.0.0

* config property support for `exp` and `issuer` - these are the only 2 claims that are required by MP JWT, so it will make much easier to test, every time I see a custom `exp` being set in the code I'm thinking, oh, we need to get it configured.