### PR TITLE
Refactor JWTEncryptionImpl to remove redundant code paths

### DIFF
--- a/implementation/src/main/java/io/smallrye/jwt/build/JwtEncryption.java
+++ b/implementation/src/main/java/io/smallrye/jwt/build/JwtEncryption.java
@@ -53,8 +53,8 @@ public interface JwtEncryption {
      * unless different ones have been set with {@code JwtEncryptionBuilder}.
      * A key of size 2048 bits or larger MUST be used with the 'RSA-OAEP' and 'RSA-OAEP-256' algorithms.
      *
-     * @return signed JWT token
-     * @throws JwtEncryptionException the exception if the signing operation has failed
+     * @return encrypted JWT token
+     * @throws JwtEncryptionException the exception if the encryption operation has failed
      */
     String encrypt() throws JwtEncryptionException;
 

--- a/implementation/src/main/java/io/smallrye/jwt/build/JwtEncryption.java
+++ b/implementation/src/main/java/io/smallrye/jwt/build/JwtEncryption.java
@@ -54,8 +54,8 @@ public interface JwtEncryption {
      * A key of size 2048 bits or larger MUST be used with the 'RSA-OAEP' and 'RSA-OAEP-256' algorithms.
      *
      * @return signed JWT token
-     * @throws JwtSignatureException the exception if the signing operation has failed
+     * @throws JwtEncryptionException the exception if the signing operation has failed
      */
-    String encrypt() throws JwtSignatureException;
+    String encrypt() throws JwtEncryptionException;
 
 }

--- a/implementation/src/main/java/io/smallrye/jwt/build/impl/ImplMessages.java
+++ b/implementation/src/main/java/io/smallrye/jwt/build/impl/ImplMessages.java
@@ -43,7 +43,7 @@ interface ImplMessages {
     JwtEncryptionException encryptionKeyNotFound(String keyLocation);
 
     @Message(id = 5008, value = "Please set a 'smallrye.jwt.encrypt.key-location' property")
-    JwtSignatureException keyLocationPropertyEmpty();
+    JwtEncryptionException keyLocationPropertyEmpty();
 
     @Message(id = 5009, value = "")
     JwtSignatureException signatureException(@Cause Throwable throwable);

--- a/implementation/src/main/java/io/smallrye/jwt/build/impl/ImplMessages.java
+++ b/implementation/src/main/java/io/smallrye/jwt/build/impl/ImplMessages.java
@@ -43,7 +43,7 @@ interface ImplMessages {
     JwtEncryptionException encryptionKeyNotFound(String keyLocation);
 
     @Message(id = 5008, value = "Please set a 'smallrye.jwt.encrypt.key-location' property")
-    JwtEncryptionException keyLocationPropertyEmpty();
+    JwtSignatureException keyLocationPropertyEmpty();
 
     @Message(id = 5009, value = "")
     JwtSignatureException signatureException(@Cause Throwable throwable);

--- a/implementation/src/main/java/io/smallrye/jwt/build/impl/JwtEncryptionImpl.java
+++ b/implementation/src/main/java/io/smallrye/jwt/build/impl/JwtEncryptionImpl.java
@@ -71,7 +71,7 @@ class JwtEncryptionImpl implements JwtEncryptionBuilder {
      * {@inheritDoc}
      */
     @Override
-    public String encrypt() throws JwtSignatureException {
+    public String encrypt() throws JwtEncryptionException {
         return encrypt(readKeyLocationFromConfig());
     }
 


### PR DESCRIPTION
A slight refactor of the JWTEncryptionImpl.
 Merged some of the code paths
 Corrected the Exception named in the ImplMessage to match that of the API