### PR TITLE
Improve the resource loading code

### DIFF
--- a/implementation/src/main/java/io/smallrye/jwt/KeyUtils.java
+++ b/implementation/src/main/java/io/smallrye/jwt/KeyUtils.java
@@ -16,16 +16,13 @@
  */
 package io.smallrye.jwt;
 
-import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringReader;
-import java.io.StringWriter;
 import java.math.BigInteger;
 import java.net.URL;
 import java.security.GeneralSecurityException;
@@ -63,9 +60,6 @@ import io.smallrye.jwt.algorithm.SignatureAlgorithm;
  */
 public final class KeyUtils {
 
-    private static final String HTTP_BASED_SCHEME = "http";
-    private static final String CLASSPATH_SCHEME = "classpath:";
-    private static final String FILE_SCHEME = "file:";
     private static final String RSA = "RSA";
     private static final String EC = "EC";
 
@@ -264,41 +258,11 @@ public final class KeyUtils {
 
     static String readKeyContent(String keyLocation) throws IOException {
 
-        InputStream is = null;
-
-        if (keyLocation.startsWith(HTTP_BASED_SCHEME)) {
-            // It can be PEM key at HTTP or HTTPS URL, JWK set at HTTP URL or single JWK at either HTTP or HTTPS URL
-            is = getUrlResolver().resolve(keyLocation);
-        } else if (keyLocation.startsWith(FILE_SCHEME)) {
-            is = getAsFileSystemResource(keyLocation.substring(FILE_SCHEME.length()));
-        } else if (keyLocation.startsWith(CLASSPATH_SCHEME)) {
-            is = getAsClasspathResource(keyLocation.substring(CLASSPATH_SCHEME.length()));
-        } else {
-            is = getAsFileSystemResource(keyLocation);
-            if (is == null) {
-                is = getAsClasspathResource(keyLocation);
-            }
-            if (is == null) {
-                is = getUrlResolver().resolve(keyLocation);
-            }
-        }
-
-        if (is == null) {
+        String content = ResourceUtils.readResource(keyLocation);
+        if (content == null) {
             throw JWTMessages.msg.keyNotFound(keyLocation);
         }
-
-        StringWriter contents = new StringWriter();
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(is))) {
-            String line = null;
-            while ((line = reader.readLine()) != null) {
-                contents.write(line);
-            }
-        }
-        return contents.toString();
-    }
-
-    static UrlStreamResolver getUrlResolver() {
-        return new UrlStreamResolver();
+        return content;
     }
 
     static PrivateKey tryAsPEMPrivateKey(String content) {

--- a/implementation/src/main/java/io/smallrye/jwt/ResourceUtils.java
+++ b/implementation/src/main/java/io/smallrye/jwt/ResourceUtils.java
@@ -1,0 +1,102 @@
+/*
+ *   Copyright 2019 Red Hat, Inc, and individual contributors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package io.smallrye.jwt;
+
+import java.io.BufferedReader;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.StringWriter;
+import java.net.URL;
+
+public final class ResourceUtils {
+
+    public static final String HTTP_BASED_SCHEME = "http";
+    public static final String CLASSPATH_SCHEME = "classpath:";
+    public static final String FILE_SCHEME = "file:";
+
+    private ResourceUtils() {
+    }
+
+    public static String readResource(String resourceLocation) throws IOException {
+
+        return readResource(resourceLocation, null);
+    }
+
+    public static String readResource(String resourceLocation, UrlStreamResolver urlResolver) throws IOException {
+
+        InputStream is = null;
+
+        if (resourceLocation.startsWith(HTTP_BASED_SCHEME)) {
+            // It can be PEM key at HTTP or HTTPS URL, JWK set at HTTP URL or single JWK at either HTTP or HTTPS URL
+            is = (urlResolver == null ? getUrlResolver() : urlResolver).resolve(resourceLocation);
+        } else if (resourceLocation.startsWith(FILE_SCHEME)) {
+            is = getAsFileSystemResource(resourceLocation.substring(FILE_SCHEME.length()));
+        } else if (resourceLocation.startsWith(CLASSPATH_SCHEME)) {
+            is = getAsClasspathResource(resourceLocation.substring(CLASSPATH_SCHEME.length()));
+        } else {
+            is = getAsFileSystemResource(resourceLocation);
+            if (is == null) {
+                is = getAsClasspathResource(resourceLocation);
+            }
+            if (is == null) {
+                is = getUrlResolver().resolve(resourceLocation);
+            }
+        }
+
+        if (is == null) {
+            return null;
+        }
+
+        StringWriter contents = new StringWriter();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(is))) {
+            String line = null;
+            while ((line = reader.readLine()) != null) {
+                contents.write(line);
+            }
+        }
+        return contents.toString();
+    }
+
+    public static UrlStreamResolver getUrlResolver() {
+        return new UrlStreamResolver();
+    }
+
+    public static InputStream getAsFileSystemResource(String publicKeyLocation) throws IOException {
+        try {
+            return new FileInputStream(publicKeyLocation);
+        } catch (FileNotFoundException e) {
+            return null;
+        }
+    }
+
+    public static InputStream getAsClasspathResource(String location) {
+        InputStream is = ResourceUtils.class.getResourceAsStream(location);
+        if (is == null) {
+            is = Thread.currentThread().getContextClassLoader().getResourceAsStream(location);
+        }
+        return is;
+    }
+
+    public static class UrlStreamResolver {
+        public InputStream resolve(String keyLocation) throws IOException {
+            return new URL(keyLocation).openStream();
+        }
+    }
+}

--- a/implementation/src/main/java/io/smallrye/jwt/build/impl/JwtEncryptionImpl.java
+++ b/implementation/src/main/java/io/smallrye/jwt/build/impl/JwtEncryptionImpl.java
@@ -18,7 +18,6 @@ import io.smallrye.jwt.algorithm.ContentEncryptionAlgorithm;
 import io.smallrye.jwt.algorithm.KeyEncryptionAlgorithm;
 import io.smallrye.jwt.build.JwtEncryptionBuilder;
 import io.smallrye.jwt.build.JwtEncryptionException;
-import io.smallrye.jwt.build.JwtSignatureException;
 
 /**
  * Default JWT Encryption implementation

--- a/implementation/src/main/java/io/smallrye/jwt/build/impl/JwtSigningUtils.java
+++ b/implementation/src/main/java/io/smallrye/jwt/build/impl/JwtSigningUtils.java
@@ -1,11 +1,6 @@
 package io.smallrye.jwt.build.impl;
 
-import java.io.BufferedReader;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.security.Key;
 import java.security.PrivateKey;
 import java.security.interfaces.ECPrivateKey;
@@ -13,7 +8,6 @@ import java.security.interfaces.RSAPrivateKey;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import javax.crypto.SecretKey;
 
@@ -28,6 +22,7 @@ import org.jose4j.jwt.JwtClaims;
 import org.jose4j.jwt.NumericDate;
 
 import io.smallrye.jwt.KeyUtils;
+import io.smallrye.jwt.ResourceUtils;
 import io.smallrye.jwt.algorithm.SignatureAlgorithm;
 
 /**
@@ -285,27 +280,12 @@ public class JwtSigningUtils {
     }
 
     static String readJsonContent(String jsonResName) {
-        // Try as the class path resource
-        InputStream is = JwtSigningUtils.class.getResourceAsStream(jsonResName);
-        if (is == null) {
-            is = Thread.currentThread().getContextClassLoader().getResourceAsStream(jsonResName);
-        }
-        if (is == null) {
-            // Try as the file system resource
-            if (jsonResName.startsWith("file:")) {
-                jsonResName = jsonResName.substring(5);
+        try {
+            String content = ResourceUtils.readResource(jsonResName);
+            if (content == null) {
+                throw ImplMessages.msg.failureToOpenInputStreamFromJsonResName(jsonResName);
             }
-            try {
-                is = new FileInputStream(jsonResName);
-            } catch (FileNotFoundException e) {
-                //continue
-            }
-        }
-        if (is == null) {
-            throw ImplMessages.msg.failureToOpenInputStreamFromJsonResName(jsonResName);
-        }
-        try (BufferedReader buffer = new BufferedReader(new InputStreamReader(is))) {
-            return buffer.lines().collect(Collectors.joining("\n"));
+            return content;
         } catch (IOException ex) {
             throw ImplMessages.msg.failureToReadJsonContentFromJsonResName(jsonResName, ex.getMessage(), ex);
         }

--- a/implementation/src/main/java/io/smallrye/jwt/config/ConfigMessages.java
+++ b/implementation/src/main/java/io/smallrye/jwt/config/ConfigMessages.java
@@ -17,7 +17,9 @@ interface ConfigMessages {
     @Message(id = 2001, value = "Failed to decode the MP JWT Public Key")
     DeploymentException parsingPublicKeyFailed(@Cause Throwable throwable);
 
-    @Message(id = 2002, value = "JWTAuthContextInfo has not been initialized. Please make sure that either "
-            + "'mp.jwt.verify.publickey' or 'mp.jwt.verify.publickey.location' properties are set.")
-    IllegalStateException authContextHasNotBeenInitialized();
+    @Message(id = 2002, value = "Failed to read the public key content from 'mp.jwt.publickey.location'")
+    DeploymentException readingPublicKeyLocationFailed(@Cause Throwable throwable);
+
+    @Message(id = 2003, value = "'mp.jwt.publickey.location' is invalid")
+    DeploymentException invalidPublicKeyLocation();
 }

--- a/implementation/src/test/java/io/smallrye/jwt/auth/principal/KeyLocationResolverTest.java
+++ b/implementation/src/test/java/io/smallrye/jwt/auth/principal/KeyLocationResolverTest.java
@@ -42,8 +42,9 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import io.smallrye.jwt.KeyUtils;
+import io.smallrye.jwt.ResourceUtils;
+import io.smallrye.jwt.ResourceUtils.UrlStreamResolver;
 import io.smallrye.jwt.algorithm.SignatureAlgorithm;
-import io.smallrye.jwt.auth.principal.KeyLocationResolver.UrlStreamResolver;
 
 @RunWith(MockitoJUnitRunner.class)
 public class KeyLocationResolverTest {
@@ -170,7 +171,7 @@ public class KeyLocationResolverTest {
         contextInfo.setJwksRefreshInterval(10);
 
         Mockito.doThrow(new JoseException("")).when(httpsJwks).refresh();
-        Mockito.doReturn(KeyLocationResolver.getAsClasspathResource("publicCrt.pem"))
+        Mockito.doReturn(ResourceUtils.getAsClasspathResource("publicCrt.pem"))
                 .when(urlResolver).resolve(Mockito.any());
         KeyLocationResolver keyLocationResolver = new KeyLocationResolver(contextInfo) {
             protected HttpsJwks initializeHttpsJwks() {


### PR DESCRIPTION
This PR does the following:
 - Moves the resource loading code into `ResourceUtils` to make it consistent across all of smallrye-jwt, so that the keys (for signing, encrypting, verifying, decrypting), as well as the claim resources (builder API) can be loaded from everywhere.
 - Started with enforcing early that `mp.jwt.publickey.location` points to the actual key(s), this in fact will be closer to the spec expectations. (I'm still keeping initializing `http(s)` locations in `KeyLocationResolver` as Keycloak/etc can be a few secs behind at the start up time, but I'll probably, in the next phase, will try to init them early as well, and if it fails - then let `KeyLocationResolver` handle it...). CC @FroMage, Stephane has asked for it after spending a few hours chasing the problem with an extra space in the location property :-). This will also make things a bit faster.... 