### PR TITLE
Issue#253 Use a Galleon provisioned WildFly Elytron based configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
     <version.weld-junit4>2.0.1.Final</version.weld-junit4>
     <version.galleon>4.2.5.Final</version.galleon>
     <version.wildfly>20.0.0.Final</version.wildfly>
+    <version.wildfly.plugin>2.0.2.Final</version.wildfly.plugin>
     <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/testsuite/basic/target/site/jacoco-aggregate/jacoco.xml,${project.basedir}/../testsuite/basic/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
     <version.resteasy>3.12.1.Final</version.resteasy>
     <version.mokito>3.3.3</version.mokito>
     <version.weld-junit4>2.0.1.Final</version.weld-junit4>
+    <version.wildfly>20.0.0.Final</version.wildfly>
     <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/testsuite/basic/target/site/jacoco-aggregate/jacoco.xml,${project.basedir}/../testsuite/basic/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
   </properties>
 
@@ -129,6 +130,7 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+
 
   <build>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
     <version.resteasy>3.12.1.Final</version.resteasy>
     <version.mokito>3.3.3</version.mokito>
     <version.weld-junit4>2.0.1.Final</version.weld-junit4>
+    <version.galleon>4.2.5.Final</version.galleon>
     <version.wildfly>20.0.0.Final</version.wildfly>
     <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/testsuite/basic/target/site/jacoco-aggregate/jacoco.xml,${project.basedir}/../testsuite/basic/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
   </properties>

--- a/testsuite/tck/pom.xml
+++ b/testsuite/tck/pom.xml
@@ -133,38 +133,56 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <environmentVariables>
-                <JBOSS_HOME>${project.build.directory}/wildfly-servlet-${version.wildfly}</JBOSS_HOME>
+                <JBOSS_HOME>${project.build.directory}/wildfly</JBOSS_HOME>
               </environmentVariables>
             </configuration>
           </plugin>
           <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-dependency-plugin</artifactId>
+            <groupId>org.jboss.galleon</groupId>
+            <artifactId>galleon-maven-plugin</artifactId>
+            <version>${version.galleon}</version>
             <executions>
               <execution>
-                <id>unpack</id>
-                <phase>process-test-classes</phase>
                 <goals>
-                  <goal>unpack</goal>
+                  <goal>provision</goal>
                 </goals>
                 <configuration>
-                  <artifactItems>
-                    <artifactItem>
+                  <install-dir>${project.build.directory}/wildfly</install-dir>
+                  <plugin-options>
+                    <optional-packages>passive+</optional-packages>
+                  </plugin-options>
+                  <feature-packs>
+                    <feature-pack>
                       <groupId>org.wildfly</groupId>
-                      <artifactId>wildfly-servlet-dist</artifactId>
+                      <artifactId>wildfly-galleon-pack</artifactId>
                       <version>${version.wildfly}</version>
-                      <type>zip</type>
-                      <overWrite>false</overWrite>
-                      <outputDirectory>${project.build.directory}</outputDirectory>
-                    </artifactItem>
-                  </artifactItems>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
+                      <inherit-configs>false</inherit-configs>
+                      <inherit-packages>false</inherit-packages>
+                      <excluded-packages>
+                        <name>product.conf</name>
+                        <name>docs.schema</name>
+                      </excluded-packages>
+                    </feature-pack>
+                  </feature-packs>
+                  <configs>
+                    <config>
+                      <name>standalone.xml</name>
+                      <model>standalone</model>
+                      <layers>
+                          <layer>jmx-remoting</layer>
+                          <layer>legacy-management</layer>
+                          <layer>legacy-security</layer>
+                          <layer>web-server</layer>
+                      </layers>
+                    </config>
+                </configs>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </build>
+  </profile>
 
     <profile>
       <id>coverage</id>

--- a/testsuite/tck/pom.xml
+++ b/testsuite/tck/pom.xml
@@ -169,9 +169,10 @@
                       <name>standalone.xml</name>
                       <model>standalone</model>
                       <layers>
+                          <layer>core-tools</layer>
+                          <layer>elytron</layer>
                           <layer>jmx-remoting</layer>
-                          <layer>legacy-management</layer>
-                          <layer>legacy-security</layer>
+                          <layer>secure-management</layer>
                           <layer>web-server</layer>
                       </layers>
                     </config>
@@ -179,6 +180,28 @@
               </configuration>
             </execution>
           </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.wildfly.plugins</groupId>
+          <artifactId>wildfly-maven-plugin</artifactId>
+          <version>${version.wildfly.plugin}</version>
+          <executions>
+            <execution>
+              <phase>process-test-resources</phase>
+              <goals>
+                <goal>execute-commands</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <offline>true</offline>
+            <commands>
+              <command>embed-server</command>
+              <command>/subsystem=undertow/application-security-domain=other:add(security-domain=ApplicationDomain, integrated-jaspi=false)</command>
+            </commands>
+            <jboss-home>${project.build.directory}/wildfly</jboss-home>
+            <stdout>${project.build.directory}/wildfly-plugin.log</stdout>
+          </configuration>
         </plugin>
       </plugins>
     </build>

--- a/testsuite/tck/pom.xml
+++ b/testsuite/tck/pom.xml
@@ -205,6 +205,19 @@
         </plugin>
       </plugins>
     </build>
+
+    <repositories>
+        <repository>
+            <id>JBoss</id>
+            <name>JBoss Repository</name>
+            <url>https://repository.jboss.org/nexus/content/groups/public-jboss/</url>
+        </repository>
+        <repository>
+            <id>Red Hat</id>
+            <name>Red Hat Repository</name>
+            <url>https://maven.repository.redhat.com/ga/</url>
+        </repository>
+    </repositories>
   </profile>
 
     <profile>


### PR DESCRIPTION
I suspect this may need some discussion to see if some aspects should more to smallrye parent but in general this update instead of unzipping a servlet feature pack distribution uses Galleon to dynamically provision a server with the minimal set of layers needed to run the TCK in this form.

This change also switches to using WildFly Elytron instead of the legacy security provided by PicketBox, at some point in the future we will be moving to remove PicketBox from the configurations - additionally it is know issues will be experienced with PicketBox from Java 14 and onwards.