### PR TITLE
Support public RSA keys with 1024 bit length

### DIFF
--- a/doc/modules/ROOT/pages/configuration.adoc
+++ b/doc/modules/ROOT/pages/configuration.adoc
@@ -33,6 +33,7 @@ Smallrye JWT supports many properties which can be used to customize the token p
 |Property Name|Default|Description
 |smallrye.jwt.verify.algorithm|`RS256`|Signature algorithm. Set it to `ES256` to support the Elliptic Curve signature algorithm.
 |smallrye.jwt.verify.key-format|`ANY`|Set this property to a specific key format such as `PEM_KEY`, `PEM_CERTIFICATE`, `JWK` or `JWK_BASE64URL` to optimize the way the verification key is loaded.
+|smallrye.jwt.verify.relax-key-validation|false|Relax the validattion of the verification keys, setting this property to `true` will allow public RSA keys with the length less than 2048 bit.
 |smallrye.jwt.token.header|`Authorization`|Set this property if another header such as `Cookie` is used to pass the token.
 |smallrye.jwt.token.cookie|none|Name of the cookie containing a token. This property will be effective only if  `smallrye.jwt.token.header` is set to `Cookie`.
 |smallrye.jwt.always-check-authorization|false|Set this property to `true` for `Authorization` header be checked even if the `smallrye.jwt.token.header` is set to `Cookie` but no cookie with a `smallrye.jwt.token.cookie` name exists.

--- a/implementation/src/main/java/io/smallrye/jwt/auth/principal/DefaultJWTTokenParser.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/principal/DefaultJWTTokenParser.java
@@ -85,6 +85,9 @@ public class DefaultJWTTokenParser {
 
             setExpectedAudience(builder, authContextInfo);
 
+            if (authContextInfo.isRelaxVerificationKeyValidation()) {
+                builder.setRelaxVerificationKeyValidation();
+            }
             JwtConsumer jwtConsumer = builder.build();
 
             //  Validate the JWT and process it to the Claims

--- a/implementation/src/main/java/io/smallrye/jwt/auth/principal/JWTAuthContextInfo.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/principal/JWTAuthContextInfo.java
@@ -52,6 +52,7 @@ public class JWTAuthContextInfo {
     private Set<String> expectedAudience;
     private String groupsSeparator = " ";
     private Set<String> requiredClaims;
+    private boolean relaxVerificationKeyValidation;
 
     /**
      * Flag that indicates whether the issuer is required and validated, or ignored, new in MP-JWT 1.1.
@@ -320,6 +321,15 @@ public class JWTAuthContextInfo {
                 ", expectedAudience=" + expectedAudience +
                 ", groupsSeparator='" + groupsSeparator + '\'' +
                 ", requireIssuer=" + requireIssuer +
+                ", relaxVerificationKeyValidation=" + relaxVerificationKeyValidation +
                 '}';
+    }
+
+    public boolean isRelaxVerificationKeyValidation() {
+        return relaxVerificationKeyValidation;
+    }
+
+    public void setRelaxVerificationKeyValidation(boolean relaxVerificationKeyValidation) {
+        this.relaxVerificationKeyValidation = relaxVerificationKeyValidation;
     }
 }

--- a/implementation/src/main/java/io/smallrye/jwt/config/JWTAuthContextInfoProvider.java
+++ b/implementation/src/main/java/io/smallrye/jwt/config/JWTAuthContextInfoProvider.java
@@ -272,6 +272,14 @@ public class JWTAuthContextInfoProvider {
     private KeyFormat keyFormat;
 
     /**
+     * Relax the validation of the verification keys.
+     * Public RSA keys with the 1024 bit length will be allowed if this property is set to 'true'.
+     */
+    @Inject
+    @ConfigProperty(name = "smallrye.jwt.verify.relax-key-validation", defaultValue = "false")
+    private boolean relaxVerificationKeyValidation;
+
+    /**
      * The audience value(s) that identify valid recipient(s) of a JWT. Audience validation
      * will succeed, if any one of the provided values is equal to any one of the values of
      * the "aud" claim in the JWT. The config value should be specified as a comma-separated
@@ -350,6 +358,7 @@ public class JWTAuthContextInfoProvider {
         contextInfo.setExpectedAudience(expectedAudience.orElse(null));
         contextInfo.setGroupsSeparator(groupsSeparator);
         contextInfo.setRequiredClaims(requiredClaims.orElse(null));
+        contextInfo.setRelaxVerificationKeyValidation(relaxVerificationKeyValidation);
 
         return Optional.of(contextInfo);
     }
@@ -470,6 +479,10 @@ public class JWTAuthContextInfoProvider {
 
     public Optional<Set<String>> getRequiredClaims() {
         return requiredClaims;
+    }
+
+    public boolean isRelaxVerificationKeyValidation() {
+        return relaxVerificationKeyValidation;
     }
 
     @Produces


### PR DESCRIPTION
Darran @darranl has identified the specification problem where RSA keys with the `1024` bit length are required to be supported but neither TCK enforces it nor smallrye-jwt itself supports such keys. It concerns the WildFly security team. 
Darran has proposed to drop `1024` key length completely in `MP JWT 1.2` (which is very sound since MP JWT builds on top of the Jose specs and the JWA spec in particular requiring a minimum `2048` RSA key length) but due to the pushback we will have it in MP JWT 1.2.
This PR makes sure it is supported OOB with an option for the users to block `1024` bit length keys