### PR TITLE
JWT Builder shortcuts

### DIFF
--- a/implementation/src/main/java/io/smallrye/jwt/build/Jwt.java
+++ b/implementation/src/main/java/io/smallrye/jwt/build/Jwt.java
@@ -2,6 +2,7 @@ package io.smallrye.jwt.build;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 
 import javax.json.JsonArray;
 import javax.json.JsonObject;
@@ -94,5 +95,258 @@ public final class Jwt {
      */
     public static JwtClaimsBuilder claims(JsonWebToken jwt) {
         return JwtProvider.provider().claims(jwt);
+    }
+
+    /**
+     * Creates a new instance of {@link JwtClaimsBuilder} with a specified claim.
+     *
+     * @param name the claim name
+     * @param value the claim value
+     * @return {@link JwtClaimsBuilder}
+     */
+    public static JwtClaimsBuilder claim(String name, Object value) {
+        return claims().claim(name, value);
+    }
+
+    /**
+     * Creates a new instance of {@link JwtClaimsBuilder} with a specified issuer.
+     *
+     * @param issuer the issuer
+     * @return {@link JwtClaimsBuilder}
+     */
+    public static JwtClaimsBuilder issuer(String issuer) {
+        return claims().issuer(issuer);
+    }
+
+    /**
+     * Creates a new instance of {@link JwtClaimsBuilder} with a specified subject.
+     *
+     * @param subject the subject
+     * @return {@link JwtClaimsBuilder}
+     */
+    public static JwtClaimsBuilder subject(String subject) {
+        return claims().subject(subject);
+    }
+
+    /**
+     * Creates a new instance of {@link JwtClaimsBuilder} with a specified 'groups' claim.
+     *
+     * @param groups the groups
+     * @return {@link JwtClaimsBuilder}
+     */
+    public static JwtClaimsBuilder groups(String groups) {
+        return claims().groups(groups);
+    }
+
+    /**
+     * Creates a new instance of {@link JwtClaimsBuilder} with a specified 'groups' claim.
+     *
+     * @param groups the groups
+     * @return {@link JwtClaimsBuilder}
+     */
+    public static JwtClaimsBuilder groups(Set<String> groups) {
+        return claims().groups(groups);
+    }
+
+    /**
+     * Creates a new instance of {@link JwtClaimsBuilder} with a specified 'audience' claim.
+     *
+     * @param groups the audience
+     * @return {@link JwtClaimsBuilder}
+     */
+    public static JwtClaimsBuilder audience(String audience) {
+        return claims().audience(audience);
+    }
+
+    /**
+     * Creates a new instance of {@link JwtClaimsBuilder} with a specified 'audience' claim.
+     *
+     * @param groups the audience
+     * @return {@link JwtClaimsBuilder}
+     */
+    public static JwtClaimsBuilder audience(Set<String> audiences) {
+        return claims().audience(audiences);
+    }
+
+    /**
+     * Creates a new instance of {@link JwtClaimsBuilder} with a specified 'upn' claim.
+     *
+     * @param upn the upn
+     * @return {@link JwtClaimsBuilder}
+     */
+    public static JwtClaimsBuilder upn(String upn) {
+        return claims().upn(upn);
+    }
+
+    /**
+     * Creates a new instance of {@link JwtClaimsBuilder} with a specified 'preferred_username' claim.
+     *
+     * @param preferredUserName the preferred user name
+     * @return {@link JwtClaimsBuilder}
+     */
+    public static JwtClaimsBuilder preferredUserName(String preferredUserName) {
+        return claims().preferredUserName(preferredUserName);
+    }
+
+    /**
+     * Sign the claims loaded from a JSON resource using 'RS256' algorithm with a private RSA key
+     * loaded from the location set with the "smallrye.jwt.sign.key-location".
+     * Private RSA key of size 2048 bits or larger MUST be used.
+     *
+     * The 'iat' (issued at time), 'exp' (expiration time) and 'jit' (unique token identifier) claims
+     * will be and the `iss` issuer claim may be set by the implementation unless they have already been set.
+     * See {@link JwtClaimsBuilder} description for more information.
+     *
+     * @param jsonLocation JSON resource location
+     * @return signed JWT token
+     * @throws JwtSignatureException the exception if the signing operation has failed
+     */
+    public static String sign(String jsonLocation) {
+        return claims(jsonLocation).sign();
+    }
+
+    /**
+     * Sign the claims using 'RS256' algorithm with a private RSA key
+     * loaded from the location set with the "smallrye.jwt.sign.key-location".
+     * Private RSA key of size 2048 bits or larger MUST be used.
+     *
+     * The 'iat' (issued at time), 'exp' (expiration time) and 'jit' (unique token identifier) claims
+     * will be and the `iss` issuer claim may be set by the implementation unless they have already been set.
+     * See {@link JwtClaimsBuilder} description for more information.
+     *
+     * @param claims the map with the claim name and value pairs. Claim value is converted to String unless it is
+     *        an instance of {@link Boolean}, {@link Number}, {@link Collection}, {@link Map},
+     *        {@link JsonObject} or {@link JsonArray}
+     * @return signed JWT token
+     * @throws JwtSignatureException the exception if the signing operation has failed
+     */
+    public static String sign(Map<String, Object> claims) {
+        return claims(claims).sign();
+    }
+
+    /**
+     * Sign the claims loaded from {@link JsonObject} using 'RS256' algorithm with a private RSA key
+     * loaded from the location set with the "smallrye.jwt.sign.key-location".
+     * Private RSA key of size 2048 bits or larger MUST be used.
+     *
+     * The 'iat' (issued at time), 'exp' (expiration time) and 'jit' (unique token identifier) claims
+     * will be and the `iss` issuer claim may be set by the implementation unless they have already been set.
+     * See {@link JwtClaimsBuilder} description for more information.
+     *
+     * @param jsonObject {@link JsonObject} containing the claims.
+     * @return signed JWT token
+     * @throws JwtSignatureException the exception if the signing operation has failed
+     */
+    public static String sign(JsonObject jsonObject) {
+        return claims(jsonObject).sign();
+    }
+
+    /**
+     * Encrypt the claims loaded from a JSON resource using 'RSA-OAEP-256' algorithm with a public RSA key
+     * loaded from the location set with the "smallrye.jwt.encrypt.key-location".
+     * Public RSA key of size 2048 bits or larger MUST be used.
+     *
+     * The 'iat' (issued at time), 'exp' (expiration time) and 'jit' (unique token identifier) claims
+     * will be and the `iss` issuer claim may be set by the implementation unless they have already been set.
+     * See {@link JwtClaimsBuilder} description for more information.
+     *
+     * @param jsonLocation JSON resource location
+     * @return encrypted JWT token
+     * @throws JwtEncryptionException the exception if the encryption operation has failed
+     */
+    public static String encrypt(String jsonLocation) {
+        return claims(jsonLocation).jwe().encrypt();
+    }
+
+    /**
+     * Encrypt the claims using 'RSA-OAEP-256' algorithm with a public RSA key
+     * loaded from the location set with the "smallrye.jwt.encrypt.key-location".
+     * Public RSA key of size 2048 bits or larger MUST be used.
+     *
+     * The 'iat' (issued at time), 'exp' (expiration time) and 'jit' (unique token identifier) claims
+     * will be and the `iss` issuer claim may be set by the implementation unless they have already been set.
+     * See {@link JwtClaimsBuilder} description for more information.
+     *
+     * @param claims the map with the claim name and value pairs. Claim value is converted to String unless it is
+     *        an instance of {@link Boolean}, {@link Number}, {@link Collection}, {@link Map},
+     *        {@link JsonObject} or {@link JsonArray}
+     * @return encrypted JWT token
+     * @throws JwtEncryptionException the exception if the encryption operation has failed
+     */
+    public static String encrypt(Map<String, Object> claims) {
+        return claims(claims).jwe().encrypt();
+    }
+
+    /**
+     * Encrypt the claims loaded from {@link JsonObject} using 'RSA-OAEP-256' algorithm with a public RSA key
+     * loaded from the location set with the "smallrye.jwt.encrypt.key-location".
+     * Public RSA key of size 2048 bits or larger MUST be used.
+     *
+     * The 'iat' (issued at time), 'exp' (expiration time) and 'jit' (unique token identifier) claims
+     * will be and the `iss` issuer claim may be set by the implementation unless they have already been set.
+     * See {@link JwtClaimsBuilder} description for more information.
+     *
+     * @param jsonObject {@link JsonObject} containing the claims.
+     * @return encrypted JWT token
+     * @throws JwtEncryptionException the exception if the encryption operation has failed
+     */
+    public static String encrypt(JsonObject jsonObject) {
+        return claims(jsonObject).jwe().encrypt();
+    }
+
+    /**
+     * Sign the claims loaded from a JSON resource using 'RS256' algorithm with a private RSA key
+     * loaded from the location set with the "smallrye.jwt.sign.key-location" and encrypt the inner JWT using
+     * 'RSA-OAEP-256' algorithm with a public RSA key loaded from the location set with the "smallrye.jwt.encrypt.key-location".
+     * Public RSA key of size 2048 bits or larger MUST be used.
+     *
+     * The 'iat' (issued at time), 'exp' (expiration time) and 'jit' (unique token identifier) claims
+     * will be and the `iss` issuer claim may be set by the implementation unless they have already been set.
+     * See {@link JwtClaimsBuilder} description for more information.
+     *
+     * @param jsonLocation JSON resource location
+     * @return encrypted JWT token
+     * @throws JwtEncryptionException the exception if the encryption operation has failed
+     */
+    public static String innerSignAndEncrypt(String jsonLocation) {
+        return claims(jsonLocation).innerSign().encrypt();
+    }
+
+    /**
+     * Sign the claims using 'RS256' algorithm with a private RSA key
+     * loaded from the location set with the "smallrye.jwt.sign.key-location" and encrypt the inner JWT using
+     * 'RSA-OAEP-256' algorithm with a public RSA key loaded from the location set with the "smallrye.jwt.encrypt.key-location".
+     * Public RSA key of size 2048 bits or larger MUST be used.
+     *
+     * The 'iat' (issued at time), 'exp' (expiration time) and 'jit' (unique token identifier) claims
+     * will be and the `iss` issuer claim may be set by the implementation unless they have already been set.
+     * See {@link JwtClaimsBuilder} description for more information.
+     *
+     * @param claims the map with the claim name and value pairs. Claim value is converted to String unless it is
+     *        an instance of {@link Boolean}, {@link Number}, {@link Collection}, {@link Map},
+     *        {@link JsonObject} or {@link JsonArray}
+     * @return encrypted JWT token
+     * @throws JwtEncryptionException the exception if the encryption operation has failed
+     */
+    public static String innerSignAndEncrypt(Map<String, Object> claims) {
+        return claims(claims).innerSign().encrypt();
+    }
+
+    /**
+     * Sign the claims loaded from {@link JsonObject} using 'RS256' algorithm with a private RSA key
+     * loaded from the location set with the "smallrye.jwt.sign.key-location" and encrypt the inner JWT using
+     * 'RSA-OAEP-256' algorithm with a public RSA key loaded from the location set with the "smallrye.jwt.encrypt.key-location".
+     * Public RSA key of size 2048 bits or larger MUST be used.
+     *
+     * The 'iat' (issued at time), 'exp' (expiration time) and 'jit' (unique token identifier) claims
+     * will be and the `iss` issuer claim may be set by the implementation unless they have already been set.
+     * See {@link JwtClaimsBuilder} description for more information.
+     *
+     * @param jsonObject {@link JsonObject} containing the claims.
+     * @return encrypted JWT token
+     * @throws JwtEncryptionException the exception if the encryption operation has failed
+     */
+    public static String innerSignAndEncrypt(JsonObject jsonObject) {
+        return claims(jsonObject).innerSign().encrypt();
     }
 }

--- a/implementation/src/main/java/io/smallrye/jwt/build/JwtClaimsBuilder.java
+++ b/implementation/src/main/java/io/smallrye/jwt/build/JwtClaimsBuilder.java
@@ -1,5 +1,6 @@
 package io.smallrye.jwt.build;
 
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
@@ -68,12 +69,32 @@ public interface JwtClaimsBuilder extends JwtSignature {
     JwtClaimsBuilder issuedAt(long issuedAt);
 
     /**
+     * Set an issuedAt 'iat' claim
+     * 
+     * @param issuedAt the issuedAt time in seconds
+     * @return JwtClaimsBuilder
+     */
+    default JwtClaimsBuilder issuedAt(Instant issuedAt) {
+        return issuedAt(issuedAt.getEpochSecond());
+    }
+
+    /**
      * Set an expiry 'exp' claim
      * 
      * @param expiredAt the expiry time in seconds
      * @return JwtClaimsBuilder
      */
     JwtClaimsBuilder expiresAt(long expiredAt);
+
+    /**
+     * Set an expiry 'exp' claim
+     * 
+     * @param expiredAt the expiry time in seconds
+     * @return JwtClaimsBuilder
+     */
+    default JwtClaimsBuilder expiresAt(Instant expiredAt) {
+        return expiresAt(expiredAt.getEpochSecond());
+    }
 
     /**
      * Set a single value 'groups' claim

--- a/implementation/src/test/java/io/smallrye/jwt/build/JwtClaimShortcutsTest.java
+++ b/implementation/src/test/java/io/smallrye/jwt/build/JwtClaimShortcutsTest.java
@@ -1,0 +1,108 @@
+/*
+ *   Copyright 2019 Red Hat, Inc, and individual contributors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package io.smallrye.jwt.build;
+
+import java.util.List;
+
+import org.jose4j.jws.JsonWebSignature;
+import org.jose4j.jwt.JwtClaims;
+import org.junit.Assert;
+import org.junit.Test;
+
+import io.smallrye.jwt.KeyUtils;
+
+public class JwtClaimShortcutsTest {
+
+    @Test
+    public void testCustomClaim() throws Exception {
+        verifyJwt(
+                Jwt.claim("customClaim", "custom-value").sign(), "customClaim", "custom-value");
+    }
+
+    @Test
+    public void testUpn() throws Exception {
+        verifyJwt(Jwt.upn("upn").sign(), "upn", "upn");
+    }
+
+    @Test
+    public void testSubject() throws Exception {
+        verifyJwt(Jwt.subject("sub").sign(), "sub", "sub");
+    }
+
+    @Test
+    public void testPreferredUserName() throws Exception {
+        verifyJwt(Jwt.preferredUserName("alice").sign(), "preferred_username", "alice");
+    }
+
+    @Test
+    public void testGroups() throws Exception {
+        verifyJwtWithArray(Jwt.groups("user").sign(), "groups", "user");
+    }
+
+    @Test
+    public void testAudience() throws Exception {
+        verifyJwt(Jwt.audience("aud").sign(), "aud", "aud");
+    }
+
+    @Test
+    public void testIssuer() throws Exception {
+        verifyJwtWithIssuer(Jwt.issuer("iss").sign());
+    }
+
+    private static void verifyJwt(String jwt, String customClaim, String customValue) throws Exception {
+        JsonWebSignature jws = new JsonWebSignature();
+        jws.setKey(KeyUtils.readPublicKey("/publicKey.pem"));
+        jws.setCompactSerialization(jwt);
+        Assert.assertTrue(jws.verifySignature());
+        JwtClaims claims = JwtClaims.parse(jws.getPayload());
+        Assert.assertEquals(4, claims.getClaimsMap().size());
+        Assert.assertEquals(customValue, claims.getClaimValue(customClaim));
+        Assert.assertNotNull(claims.getIssuedAt());
+        Assert.assertNotNull(claims.getExpirationTime());
+        Assert.assertNotNull(claims.getJwtId());
+    }
+
+    private static void verifyJwtWithIssuer(String jwt) throws Exception {
+        JsonWebSignature jws = new JsonWebSignature();
+        jws.setKey(KeyUtils.readPublicKey("/publicKey.pem"));
+        jws.setCompactSerialization(jwt);
+        Assert.assertTrue(jws.verifySignature());
+        JwtClaims claims = JwtClaims.parse(jws.getPayload());
+        Assert.assertEquals(4, claims.getClaimsMap().size());
+        Assert.assertEquals("iss", claims.getIssuer());
+        Assert.assertNotNull(claims.getIssuedAt());
+        Assert.assertNotNull(claims.getExpirationTime());
+        Assert.assertNotNull(claims.getJwtId());
+    }
+
+    private static void verifyJwtWithArray(String jwt, String customClaim, String customValue) throws Exception {
+        JsonWebSignature jws = new JsonWebSignature();
+        jws.setKey(KeyUtils.readPublicKey("/publicKey.pem"));
+        jws.setCompactSerialization(jwt);
+        Assert.assertTrue(jws.verifySignature());
+        JwtClaims claims = JwtClaims.parse(jws.getPayload());
+        Assert.assertEquals(4, claims.getClaimsMap().size());
+        @SuppressWarnings("unchecked")
+        List<String> list = (List<String>) claims.getClaimValue(customClaim);
+        Assert.assertEquals(1, list.size());
+        Assert.assertEquals(customValue, list.get(0));
+        Assert.assertNotNull(claims.getIssuedAt());
+        Assert.assertNotNull(claims.getExpirationTime());
+        Assert.assertNotNull(claims.getJwtId());
+    }
+
+}

--- a/implementation/src/test/java/io/smallrye/jwt/build/JwtSignEncryptTest.java
+++ b/implementation/src/test/java/io/smallrye/jwt/build/JwtSignEncryptTest.java
@@ -19,7 +19,11 @@ package io.smallrye.jwt.build;
 import java.security.Key;
 import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.util.Collections;
 import java.util.Map;
+
+import javax.json.Json;
+import javax.json.JsonObject;
 
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.spi.ConfigSource;
@@ -43,6 +47,10 @@ public class JwtSignEncryptTest {
                 .innerSign()
                 .encrypt();
 
+        checkRsaInnerSignedEncryptedClaims(jweCompact);
+    }
+
+    private void checkRsaInnerSignedEncryptedClaims(String jweCompact) throws Exception {
         checkJweHeaders(jweCompact, "RSA-OAEP-256", null);
 
         JsonWebEncryption jwe = getJsonWebEncryption(jweCompact);
@@ -56,6 +64,48 @@ public class JwtSignEncryptTest {
         checkClaimsAndJwsHeaders(jwtCompact, claims, "RS256", null);
 
         Assert.assertEquals("custom-value", claims.getClaimValue("customClaim"));
+    }
+
+    @Test
+    public void testInnerSignAndEncryptMapOfClaims() throws Exception {
+        String jweCompact = Jwt.claims(Collections.singletonMap("customClaim", "custom-value"))
+                .innerSign().encrypt();
+        checkRsaInnerSignedEncryptedClaims(jweCompact);
+    }
+
+    @Test
+    public void testInnerSignAndEncryptMapOfClaimsShortcut() throws Exception {
+        String jweCompact = Jwt.innerSignAndEncrypt(Collections.singletonMap("customClaim", "custom-value"));
+
+        checkRsaInnerSignedEncryptedClaims(jweCompact);
+    }
+
+    @Test
+    public void testInnerSignAndEncryptJsonObject() throws Exception {
+        JsonObject json = Json.createObjectBuilder().add("customClaim", "custom-value").build();
+        String jweCompact = Jwt.claims(json).innerSign().encrypt();
+
+        checkRsaInnerSignedEncryptedClaims(jweCompact);
+    }
+
+    @Test
+    public void testInnerSignAndEncryptJsonObjectShortcut() throws Exception {
+        JsonObject json = Json.createObjectBuilder().add("customClaim", "custom-value").build();
+        String jweCompact = Jwt.innerSignAndEncrypt(json);
+
+        checkRsaInnerSignedEncryptedClaims(jweCompact);
+    }
+
+    @Test
+    public void testInnerSignAndEncryptExistingClaims() throws Exception {
+        String jweCompact = Jwt.claims("/customClaim.json").innerSign().encrypt();
+        checkRsaInnerSignedEncryptedClaims(jweCompact);
+    }
+
+    @Test
+    public void testInnerSignAndEncryptExistingClaimsShortcut() throws Exception {
+        String jweCompact = Jwt.innerSignAndEncrypt("/customClaim.json");
+        checkRsaInnerSignedEncryptedClaims(jweCompact);
     }
 
     @Test

--- a/implementation/src/test/resources/customClaim.json
+++ b/implementation/src/test/resources/customClaim.json
@@ -1,0 +1,3 @@
+{
+  "customClaim": "custom-value"
+}


### PR DESCRIPTION
This PR continues with making the builder API as compact as possible, introduces the shortcuts to optimize some flows.

1. In the flow where the claims are built from the empty builder, `Jwt.claims()` transition is now optional, every time I see `Jwt.claims().claim("a", "b")` I think this is suboptimal. 
So, instead of `Jwt.claims().issuer("issuer").subject("sub").sign()` once can just do `Jwt.issuer("issuer").subject("sub").sign()`.

2. Creates `sign()`, `encrypt` and `innerSignAndEncrypt` shortcuts to optimize the flows where the keys are configured and where the default RSA algorithms are used:
 - `Jwt.claims("/token.json").sign()` is equivalent to `Jwt.sign("/token.json")`
(same for the maps and jsonobject)
- `Jwt.claims("/token.json").jwe().encrypt()` is equivalent to `Jwt.encrypt("/token.json")`
(same for the maps and jsonobject)
- `Jwt.claims("/token.json").innerSign().encrypt()` is equivalent to `Jwt.innerSignAndEncrypt("/token.json")`
(same for the maps and jsonobject)

3. Also added `Instant` overloads for the `iss` and `exp` claims
