### PR TITLE
Update the version to 2.2.0.SNAPSHOT

### DIFF
--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.smallrye</groupId>
     <artifactId>smallrye-jwt-parent</artifactId>
-    <version>2.1.3-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>smallrye-jwt</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <artifactId>smallrye-jwt-parent</artifactId>
-  <version>2.1.3-SNAPSHOT</version>
+  <version>2.2.0-SNAPSHOT</version>
 
   <packaging>pom</packaging>
   <name>SmallRye: MicroProfile JWT Parent</name>

--- a/release/pom.xml
+++ b/release/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-jwt-parent</artifactId>
-        <version>2.1.3-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>smallrye-jwt-release</artifactId>

--- a/testsuite/basic/pom.xml
+++ b/testsuite/basic/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.smallrye</groupId>
     <artifactId>smallrye-jwt-testsuite-parent</artifactId>
-    <version>2.1.3-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>smallrye-jwt-testsuite-basic</artifactId>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.smallrye</groupId>
     <artifactId>smallrye-jwt-parent</artifactId>
-    <version>2.1.3-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
 
   <packaging>pom</packaging>

--- a/testsuite/tck/pom.xml
+++ b/testsuite/tck/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.smallrye</groupId>
     <artifactId>smallrye-jwt-testsuite-parent</artifactId>
-    <version>2.1.3-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>smallrye-jwt-tck</artifactId>


### PR DESCRIPTION
Hi All, I'd like to move the version to `2.2.0` and release since `JWTParser` has had a new methods added and the decryption code has also been backported from `mpjwt12`. I suspect the lifespan of `2.2.x` won't be long given that `MP JWT 1.2` is hopefully is getting close and `mpjwt12` will set the version to `3.0.0`, but I thought it would be better to increase a minor version now anyway as there could be another couple of `2.2.x` releases in between....
I don't really mind much to do the next release as `2.1.3` since no breaking changes have been introduced but again I'll feel better when showing the release log to the Quarkus QE team if it becomes `2.2.0` :-) 