### PR TITLE
Relax the key validation by default on MP JWT 1.2 branch

### DIFF
--- a/implementation/src/main/java/io/smallrye/jwt/auth/principal/JWTAuthContextInfo.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/principal/JWTAuthContextInfo.java
@@ -61,7 +61,7 @@ public class JWTAuthContextInfo {
     private Set<String> expectedAudience;
     private String groupsSeparator = " ";
     private Set<String> requiredClaims;
-    private boolean relaxVerificationKeyValidation;
+    private boolean relaxVerificationKeyValidation = true;
 
     public JWTAuthContextInfo() {
     }

--- a/implementation/src/main/java/io/smallrye/jwt/config/JWTAuthContextInfoProvider.java
+++ b/implementation/src/main/java/io/smallrye/jwt/config/JWTAuthContextInfoProvider.java
@@ -365,8 +365,8 @@ public class JWTAuthContextInfoProvider {
      * Public RSA keys with the 1024 bit length will be allowed if this property is set to 'true'.
      */
     @Inject
-    @ConfigProperty(name = "smallrye.jwt.verify.relax-key-validation", defaultValue = "false")
-    private boolean relaxVerificationKeyValidation;
+    @ConfigProperty(name = "smallrye.jwt.verify.relax-key-validation", defaultValue = "true")
+    private boolean relaxVerificationKeyValidation = true;
 
     /**
      * The audience value(s) that identify valid recipient(s) of a JWT. Audience validation

--- a/testsuite/basic/src/test/java/io/smallrye/jwt/auth/principal/DefaultJWTTokenParserTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/jwt/auth/principal/DefaultJWTTokenParserTest.java
@@ -46,7 +46,6 @@ public class DefaultJWTTokenParserTest {
         KeyPair pair = KeyUtils.generateKeyPair(1024);
         String jwt = TokenUtils.generateTokenString(pair.getPrivate(), "kid", "/Token1.json", null, null);
         JWTAuthContextInfo context = new JWTAuthContextInfo((RSAPublicKey) pair.getPublic(), "https://server.example.com");
-        context.setRelaxVerificationKeyValidation(true);
         assertNotNull(parser.parse(jwt, context).getJwtClaims());
     }
 
@@ -55,6 +54,7 @@ public class DefaultJWTTokenParserTest {
         KeyPair pair = KeyUtils.generateKeyPair(1024);
         String jwt = TokenUtils.generateTokenString(pair.getPrivate(), "kid", "/Token1.json", null, null);
         JWTAuthContextInfo context = new JWTAuthContextInfo((RSAPublicKey) pair.getPublic(), "https://server.example.com");
+        context.setRelaxVerificationKeyValidation(false);
         ParseException thrown = assertThrows("InvalidJwtException is expected",
                 ParseException.class, () -> parser.parse(jwt, context));
         assertTrue(thrown.getCause() instanceof InvalidJwtException);

--- a/testsuite/tck/src/test/resources/tck-base-suite.xml
+++ b/testsuite/tck/src/test/resources/tck-base-suite.xml
@@ -57,6 +57,7 @@
       <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.AudValidationBadAudTest" />
       <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.AudValidationMissingAudTest" />
       <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.ApplicationScopedInjectionTest" />
+      <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.RsaKeySignatureTest" />
       <class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsPEMTest" />
       <class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsPEMLocationTest" />
       <class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsPEMLocationURLTest" />


### PR DESCRIPTION
The verification key is now relaxed by default on the MP JWT 1.2 branch