### PR TITLE
Fix JWT TTL time units message

### DIFF
--- a/implementation/src/main/java/io/smallrye/jwt/auth/principal/PrincipalMessages.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/principal/PrincipalMessages.java
@@ -45,7 +45,7 @@ interface PrincipalMessages {
     ParseException failedToVerifyMaxTTL(@Cause Throwable throwable);
 
     @Message(id = 7009, value = "The Expiration Time (exp=%s) claim value cannot be more than %d"
-            + " minutes in the future relative to Issued At (iat=%s)")
+            + " seconds in the future relative to Issued At (iat=%s)")
     ParseException expExceeded(NumericDate exp, long maxTimeToLiveSecs, NumericDate iat);
 
     @Message(id = 7010, value = "Required claims are not present in the JWT")

--- a/testsuite/basic/src/test/java/io/smallrye/jwt/config/JWTAuthContextInfoProviderTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/jwt/config/JWTAuthContextInfoProviderTest.java
@@ -111,7 +111,7 @@ public class JWTAuthContextInfoProviderTest {
     @Test
     public void testGetOptionalContextInfoWithMaxTimeToLive() throws Exception {
         JWTAuthContextInfoProvider provider = JWTAuthContextInfoProvider.createWithKey(signerKeyPem, TEST_ISS);
-        provider.maxTimeToLiveSecs = Optional.of(60L); // 60 minutes
+        provider.maxTimeToLiveSecs = Optional.of(60L); // 60 seconds
         Optional<JWTAuthContextInfo> info = provider.getOptionalContextInfo();
         assertNotNull(info);
         assertTrue(info.isPresent());


### PR DESCRIPTION
Hello,

fix for JWT TTL verification failed message. Fixes the following wrong kind of ParseException message:

~~~
io.smallrye.jwt.auth.principal.ParseException: The Expiration Time (exp=NumericDate{1594285731 -> Jul 9, 2020, 11:08:51 AM CEST}) claim value cannot be more than 60 minutes in the future relative to Issued At (iat=NumericDate{1594283931 -> Jul 9, 2020, 10:38:51 AM CEST})
~~~

The maxTimeToLiveSecs attribute is in seconds instead of minutes. The ParseException should mention seconds and not minutes.

Thanks.
Regards.
