### PR TITLE
Inject JWTCallerPrincipalFactory

### DIFF
--- a/doc/modules/ROOT/pages/configuration.adoc
+++ b/doc/modules/ROOT/pages/configuration.adoc
@@ -52,3 +52,43 @@ Smallrye JWT supports many properties which can be used to customize the token p
 |smallrye.jwt.verify.aud|none|Comma separated list of the audiences that a token `aud` claim may contain.
 |smallrye.jwt.required.claims|none|Comma separated list of the claims that a token must contain.
 |===
+
+= Custom Factories
+
+`io.smallrye.jwt.auth.principal.DefaultJWTCallerPrincipalFactory` is used by default to parse and verify JWT tokens and convert them to `JsonWebToken` principals.
+It uses `MP JWT` and `smallrye-jwt` properties listed in the `Configuration` section to verify and customize JWT tokens.
+
+If you need to provide your own factory, for example, to avoid verifying the tokens again which have already been verified by the firewall, then you can either use a `ServiceLoader` mechanism by providing a `META-INF/services/io.smallrye.jwt.auth.principal.JWTCallerPrincipalFactory` resource or simply have an `Alternative` CDI bean implementation like this one:
+
+[source,java]
+----
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import javax.annotation.Priority;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Alternative;
+import org.jose4j.jwt.JwtClaims;
+import org.jose4j.jwt.consumer.InvalidJwtException;
+import io.smallrye.jwt.auth.principal.DefaultJWTCallerPrincipal;
+import io.smallrye.jwt.auth.principal.JWTAuthContextInfo;
+import io.smallrye.jwt.auth.principal.JWTCallerPrincipal;
+import io.smallrye.jwt.auth.principal.JWTCallerPrincipalFactory;
+import io.smallrye.jwt.auth.principal.ParseException;
+
+@ApplicationScoped
+@Alternative
+@Priority(1)
+public class TestJWTCallerPrincipalFactory extends JWTCallerPrincipalFactory {
+
+    @Override
+    public JWTCallerPrincipal parse(String token, JWTAuthContextInfo authContextInfo) throws ParseException {
+        try {
+            // Token has already been verified, parse the token claims only
+            String json = new String(Base64.getUrlDecoder().decode(token.split("\\.")[1]), StandardCharsets.UTF_8);
+            return new DefaultJWTCallerPrincipal(JwtClaims.parse(json));
+        } catch (InvalidJwtException ex) {
+            throw new ParseException(ex.getMessage());
+        }
+    }
+}
+----

--- a/implementation/src/main/java/io/smallrye/jwt/auth/cdi/JWTCallerPrincipalFactoryProducer.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/cdi/JWTCallerPrincipalFactoryProducer.java
@@ -1,0 +1,41 @@
+/*
+ *   Copyright 2019 Red Hat, Inc, and individual contributors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package io.smallrye.jwt.auth.cdi;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+
+import io.smallrye.jwt.auth.principal.JWTCallerPrincipalFactory;
+
+@ApplicationScoped
+public class JWTCallerPrincipalFactoryProducer {
+
+    private JWTCallerPrincipalFactory callerPrincipalFactory;
+
+    public JWTCallerPrincipalFactoryProducer() {
+        initCallerPrincipalFactory();
+    }
+
+    @Produces
+    public JWTCallerPrincipalFactory getFactory() {
+        return callerPrincipalFactory;
+    }
+
+    private void initCallerPrincipalFactory() {
+        callerPrincipalFactory = JWTCallerPrincipalFactory.instance();
+    }
+}

--- a/implementation/src/main/java/io/smallrye/jwt/auth/cdi/SmallRyeJWTAuthCDIExtension.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/cdi/SmallRyeJWTAuthCDIExtension.java
@@ -80,6 +80,7 @@ public class SmallRyeJWTAuthCDIExtension implements Extension {
         addAnnotatedType(event, beanManager, ClaimValueProducer.class);
         addAnnotatedType(event, beanManager, CommonJwtProducer.class);
         addAnnotatedType(event, beanManager, DefaultJWTParser.class);
+        addAnnotatedType(event, beanManager, JWTCallerPrincipalFactoryProducer.class);
         addAnnotatedType(event, beanManager, JsonValueProducer.class);
         addAnnotatedType(event, beanManager, JWTAuthContextInfoProvider.class);
         addAnnotatedType(event, beanManager, JWTAuthenticationFilter.class);

--- a/implementation/src/main/java/io/smallrye/jwt/auth/principal/DefaultJWTParser.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/principal/DefaultJWTParser.java
@@ -29,6 +29,7 @@ import org.eclipse.microprofile.jwt.JsonWebToken;
 
 import io.smallrye.jwt.algorithm.KeyEncryptionAlgorithm;
 import io.smallrye.jwt.algorithm.SignatureAlgorithm;
+import io.smallrye.jwt.auth.cdi.JWTCallerPrincipalFactoryProducer;
 
 /**
  * A default implementation of {@link JWTParser}.
@@ -39,13 +40,19 @@ public class DefaultJWTParser implements JWTParser {
     @Inject
     private JWTAuthContextInfo authContextInfo;
 
-    private volatile JWTCallerPrincipalFactory callerPrincipalFactory;
+    @Inject
+    private JWTCallerPrincipalFactory callerPrincipalFactory;
 
     public DefaultJWTParser() {
     }
 
     public DefaultJWTParser(JWTAuthContextInfo authContextInfo) {
+        this(authContextInfo, new JWTCallerPrincipalFactoryProducer().getFactory());
+    }
+
+    public DefaultJWTParser(JWTAuthContextInfo authContextInfo, JWTCallerPrincipalFactory factory) {
         this.authContextInfo = authContextInfo;
+        this.callerPrincipalFactory = factory;
     }
 
     public JsonWebToken parse(final String bearerToken) throws ParseException {
@@ -99,11 +106,7 @@ public class DefaultJWTParser implements JWTParser {
 
     private JWTCallerPrincipalFactory getCallerPrincipalFactory() {
         if (callerPrincipalFactory == null) {
-            synchronized (this) {
-                if (callerPrincipalFactory == null) {
-                    callerPrincipalFactory = JWTCallerPrincipalFactory.instance();
-                }
-            }
+            return new JWTCallerPrincipalFactoryProducer().getFactory();
         }
         return callerPrincipalFactory;
     }

--- a/implementation/src/test/java/io/smallrye/jwt/auth/cdi/CustomJWTCallerPrincipalFactoryTest.java
+++ b/implementation/src/test/java/io/smallrye/jwt/auth/cdi/CustomJWTCallerPrincipalFactoryTest.java
@@ -1,0 +1,61 @@
+package io.smallrye.jwt.auth.cdi;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+
+import javax.annotation.Priority;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Alternative;
+
+import org.jboss.weld.context.bound.BoundRequestContext;
+import org.jboss.weld.junit4.WeldInitiator;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import io.smallrye.jwt.auth.principal.JWTAuthContextInfo;
+import io.smallrye.jwt.auth.principal.JWTCallerPrincipal;
+import io.smallrye.jwt.auth.principal.JWTCallerPrincipalFactory;
+import io.smallrye.jwt.auth.principal.ParseException;
+
+public class CustomJWTCallerPrincipalFactoryTest {
+
+    @Rule
+    public WeldInitiator weld = WeldInitiator.of(JWTCallerPrincipalFactoryProducer.class, TestFactory.class);
+
+    BoundRequestContext context;
+
+    @Before
+    public void setUp() {
+        context = weld.select(BoundRequestContext.class).get();
+        context.associate(new HashMap<String, Object>());
+        // Start Request Scope
+        context.activate();
+    }
+
+    @After
+    public void tearDown() {
+        // End Request Scope
+        context.deactivate();
+    }
+
+    @Test
+    public void testJWTCallerPrincipalFactory() {
+        JWTCallerPrincipalFactory factory = weld.select(JWTCallerPrincipalFactory.class).get();
+        assertTrue(factory instanceof TestFactory);
+    }
+
+    @ApplicationScoped
+    @Alternative
+    @Priority(1)
+    public static class TestFactory extends JWTCallerPrincipalFactory {
+
+        @Override
+        public JWTCallerPrincipal parse(String token, JWTAuthContextInfo authContextInfo) throws ParseException {
+            return null;
+        }
+
+    }
+}

--- a/implementation/src/test/java/io/smallrye/jwt/auth/cdi/JWTCallerPrincipalFactoryProducerTest.java
+++ b/implementation/src/test/java/io/smallrye/jwt/auth/cdi/JWTCallerPrincipalFactoryProducerTest.java
@@ -1,0 +1,43 @@
+package io.smallrye.jwt.auth.cdi;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+
+import org.jboss.weld.context.bound.BoundRequestContext;
+import org.jboss.weld.junit4.WeldInitiator;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import io.smallrye.jwt.auth.principal.DefaultJWTCallerPrincipalFactory;
+import io.smallrye.jwt.auth.principal.JWTCallerPrincipalFactory;
+
+public class JWTCallerPrincipalFactoryProducerTest {
+
+    @Rule
+    public WeldInitiator weld = WeldInitiator.of(JWTCallerPrincipalFactoryProducer.class);
+
+    BoundRequestContext context;
+
+    @Before
+    public void setUp() {
+        context = weld.select(BoundRequestContext.class).get();
+        context.associate(new HashMap<String, Object>());
+        // Start Request Scope
+        context.activate();
+    }
+
+    @After
+    public void tearDown() {
+        // End Request Scope
+        context.deactivate();
+    }
+
+    @Test
+    public void testJWTCallerPrincipalFactory() {
+        JWTCallerPrincipalFactory factory = weld.select(JWTCallerPrincipalFactory.class).get();
+        assertTrue(factory instanceof DefaultJWTCallerPrincipalFactory);
+    }
+}


### PR DESCRIPTION
Fixes #144 
Fixes #193 

This is PR has been created to complete Andreas's effort (see #194) with a few minor differences. Here is the summary:
- `JWTCallerPrincipalFactory` is now injected into `DefaultJWTParser`
- I've added a producer and moved the serviceloader related code there - it is important to retain this option to avoid breaking the existing expectations around loading the factories
- TCK tests are passing, added 2 simple unit tests, updated the docs
- Added a [test in Quarkus](https://github.com/quarkusio/quarkus/compare/master...sberyozkin:smallrye-jwt-2.2.1?expand=1) as well

CC @andreas-eberle 