### PR TITLE
Simpler token symmetric signing and encryption support

### DIFF
--- a/implementation/src/main/java/io/smallrye/jwt/KeyUtils.java
+++ b/implementation/src/main/java/io/smallrye/jwt/KeyUtils.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.io.Reader;
 import java.io.StringReader;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.Key;
 import java.security.KeyFactory;
@@ -39,6 +40,8 @@ import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
 import javax.json.Json;
 import javax.json.JsonArray;
 import javax.json.JsonObject;
@@ -235,6 +238,11 @@ public final class KeyUtils {
      */
     public static PublicKey decodePublicKey(String pemEncoded) throws GeneralSecurityException {
         return decodePublicKey(pemEncoded, SignatureAlgorithm.RS256);
+    }
+
+    public static SecretKey createSecretKeyFromSecret(String secret) {
+        byte[] secretBytes = secret.getBytes(StandardCharsets.UTF_8);
+        return new SecretKeySpec(secretBytes, "AES");
     }
 
     /**

--- a/implementation/src/main/java/io/smallrye/jwt/auth/principal/DefaultJWTParser.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/principal/DefaultJWTParser.java
@@ -27,6 +27,7 @@ import javax.inject.Inject;
 
 import org.eclipse.microprofile.jwt.JsonWebToken;
 
+import io.smallrye.jwt.KeyUtils;
 import io.smallrye.jwt.algorithm.KeyEncryptionAlgorithm;
 import io.smallrye.jwt.algorithm.SignatureAlgorithm;
 import io.smallrye.jwt.auth.cdi.JWTCallerPrincipalFactoryProducer;
@@ -85,6 +86,11 @@ public class DefaultJWTParser implements JWTParser {
     }
 
     @Override
+    public JsonWebToken verify(String bearerToken, String secret) throws ParseException {
+        return verify(bearerToken, KeyUtils.createSecretKeyFromSecret(secret));
+    }
+
+    @Override
     public JsonWebToken decrypt(String bearerToken, PrivateKey key) throws ParseException {
         JWTAuthContextInfo newAuthContextInfo = copyAuthContextInfo();
         newAuthContextInfo.setPrivateDecryptionKey(key);
@@ -102,6 +108,11 @@ public class DefaultJWTParser implements JWTParser {
         newAuthContextInfo.setSecretDecryptionKey(key);
         setKeyEncryptionAlgorithmIfNeeded(newAuthContextInfo, "A256KW", KeyEncryptionAlgorithm.A256KW);
         return getCallerPrincipalFactory().parse(bearerToken, newAuthContextInfo);
+    }
+
+    @Override
+    public JsonWebToken decrypt(String bearerToken, String secret) throws ParseException {
+        return decrypt(bearerToken, KeyUtils.createSecretKeyFromSecret(secret));
     }
 
     private JWTCallerPrincipalFactory getCallerPrincipalFactory() {

--- a/implementation/src/main/java/io/smallrye/jwt/auth/principal/JWTParser.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/principal/JWTParser.java
@@ -75,6 +75,18 @@ public interface JWTParser {
     public JsonWebToken verify(final String token, SecretKey key) throws ParseException;
 
     /**
+     * Parse JWT token. The token will be verified and converted to {@link JsonWebToken}.
+     *
+     * @param token the JWT token
+     * @param secret the secret. The injected {@link JWTAuthContextInfo} configuration context
+     *        will be reused, only its secretVerificationKey property will be replaced after
+     *        converting this parameter to {@link SecretKey}.
+     * @return JsonWebToken
+     * @throws ParseException parse exception
+     */
+    public JsonWebToken verify(final String token, String secret) throws ParseException;
+
+    /**
      * Parse JWT token. The token will be decrypted and converted to {@link JsonWebToken}.
      *
      * @param token the JWT token
@@ -95,5 +107,17 @@ public interface JWTParser {
      * @throws ParseException parse exception
      */
     public JsonWebToken decrypt(final String token, SecretKey key) throws ParseException;
+
+    /**
+     * Parse JWT token. The token will be decrypted and converted to {@link JsonWebToken}.
+     *
+     * @param token the JWT token
+     * @param secret the secret. The injected {@link JWTAuthContextInfo} configuration context
+     *        will be reused, only its secretDecryptionkey property will be replaced will be replaced after
+     *        converting this parameter to {@link SecretKey}.
+     * @return JsonWebToken
+     * @throws ParseException parse exception
+     */
+    public JsonWebToken decrypt(final String token, String secret) throws ParseException;
 
 }

--- a/implementation/src/main/java/io/smallrye/jwt/build/JwtEncryption.java
+++ b/implementation/src/main/java/io/smallrye/jwt/build/JwtEncryption.java
@@ -72,4 +72,15 @@ public interface JwtEncryption {
      */
     String encrypt() throws JwtEncryptionException;
 
+    /**
+     * Encrypt the claims or inner JWT with a secret key string.
+     * 'A256KW' key encryption algorithms will be used by default unless a different one has been set with
+     * {@code JwtEncryptionBuilder}.
+     * 'A256GCM' content encryption algorithms will be used unless a different one have been set with
+     * {@code JwtEncryptionBuilder}.
+     *
+     * @return encrypted JWT token
+     * @throws JwtEncryptionException the exception if the encryption operation has failed
+     */
+    String encryptWithSecret(String secret) throws JwtEncryptionException;
 }

--- a/implementation/src/main/java/io/smallrye/jwt/build/JwtSignature.java
+++ b/implementation/src/main/java/io/smallrye/jwt/build/JwtSignature.java
@@ -55,6 +55,15 @@ public interface JwtSignature {
     String sign() throws JwtSignatureException;
 
     /**
+     * Sign the claims with a secret key string.
+     * 'HS256' algorithm will be used unless a different one has been set with {@code JwtSignatureBuilder}.
+     *
+     * @return signed JWT token
+     * @throws JwtSignatureException the exception if the signing operation has failed
+     */
+    String signWithSecret(String secret) throws JwtSignatureException;
+
+    /**
      * Sign the claims with {@link PrivateKey} and encrypt the inner JWT by moving to {@link JwtEncryptionBuilder}.
      * 'RS256' algorithm will be used unless a different one has been set with {@code JwtSignatureBuilder}.
      * A key of size 2048 bits or larger MUST be used with the 'RS256' algorithm.
@@ -101,4 +110,12 @@ public interface JwtSignature {
      */
     JwtEncryptionBuilder innerSign() throws JwtSignatureException;
 
+    /**
+     * Sign the claims with a secret key string and encrypt the inner JWT by moving to {@link JwtEncryptionBuilder}.
+     * 'HS256' algorithm will be used unless a different one has been set with {@code JwtSignatureBuilder}.
+     *
+     * @return signed JWT token
+     * @throws JwtSignatureException the exception if the signing operation has failed
+     */
+    JwtEncryptionBuilder innerSignWithSecret(String secret) throws JwtSignatureException;
 }

--- a/implementation/src/main/java/io/smallrye/jwt/build/impl/ImplMessages.java
+++ b/implementation/src/main/java/io/smallrye/jwt/build/impl/ImplMessages.java
@@ -23,10 +23,6 @@ interface ImplMessages {
             "the '%s' algorithm")
     JwtEncryptionException encryptionKeySizeMustBeHigher(String algorithmName);
 
-    @Message(id = 5002, value = "A key of size 2048 bits or larger MUST be used with " +
-            "the '%s' algorithm")
-    JwtSignatureException signKeySizeMustBeHigher(String algorithmName);
-
     @Message(id = 5003, value = "%s")
     JwtEncryptionException joseSerializationError(String errorMessage, @Cause Throwable t);
 

--- a/implementation/src/main/java/io/smallrye/jwt/build/impl/JwtEncryptionImpl.java
+++ b/implementation/src/main/java/io/smallrye/jwt/build/impl/JwtEncryptionImpl.java
@@ -76,6 +76,14 @@ class JwtEncryptionImpl implements JwtEncryptionBuilder {
      * {@inheritDoc}
      */
     @Override
+    public String encryptWithSecret(String secret) throws JwtEncryptionException {
+        return encrypt(KeyUtils.createSecretKeyFromSecret(secret));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public JwtEncryptionBuilder header(String name, Object value) {
         if ("alg".equals(name)) {
             return keyAlgorithm(toKeyEncryptionAlgorithm((String) value));

--- a/implementation/src/main/java/io/smallrye/jwt/build/impl/JwtSignatureImpl.java
+++ b/implementation/src/main/java/io/smallrye/jwt/build/impl/JwtSignatureImpl.java
@@ -76,6 +76,14 @@ class JwtSignatureImpl implements JwtSignature {
      * {@inheritDoc}
      */
     @Override
+    public String signWithSecret(String secret) throws JwtSignatureException {
+        return sign(KeyUtils.createSecretKeyFromSecret(secret));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public JwtEncryptionBuilder innerSign(PrivateKey signingKey) throws JwtSignatureException {
         return new JwtEncryptionImpl(sign(signingKey), true);
     }
@@ -114,6 +122,11 @@ class JwtSignatureImpl implements JwtSignature {
         return new JwtEncryptionImpl(sign(), true);
     }
 
+    @Override
+    public JwtEncryptionBuilder innerSignWithSecret(String secret) throws JwtSignatureException {
+        return innerSign(KeyUtils.createSecretKeyFromSecret(secret));
+    }
+
     private static boolean signingKeyConfigured() {
         try {
             ConfigProvider.getConfig().getValue("smallrye.jwt.sign.key-location", String.class);
@@ -141,10 +154,6 @@ class JwtSignatureImpl implements JwtSignature {
             jws.setAlgorithmConstraints(AlgorithmConstraints.ALLOW_ONLY_NONE);
         }
         jws.setPayload(claims.toJson());
-        if (signingKey instanceof RSAPrivateKey && algorithm.startsWith("RS")
-                && ((RSAPrivateKey) signingKey).getModulus().bitLength() < 2048) {
-            throw ImplMessages.msg.signKeySizeMustBeHigher(algorithm);
-        }
         jws.setKey(signingKey);
         try {
             return jws.getCompactSerialization();

--- a/testsuite/basic/src/test/java/io/smallrye/jwt/auth/principal/DefaultJWTParserTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/jwt/auth/principal/DefaultJWTParserTest.java
@@ -61,6 +61,14 @@ public class DefaultJWTParserTest {
     }
 
     @Test
+    public void testVerifyWithSecretString() throws Exception {
+        String secret = "AyM1SysPpbyDfgZld3umj1qzKObwVMko";
+        String jwtString = Jwt.upn("jdoe@example.com").signWithSecret(secret);
+        JsonWebToken jwt = new DefaultJWTParser().verify(jwtString, secret);
+        assertEquals("jdoe@example.com", jwt.getName());
+    }
+
+    @Test
     public void testDecryptWithRsaPrivateKey() throws Exception {
         String jwtString = Jwt.upn("jdoe@example.com")
                 .jwe().keyAlgorithm(KeyEncryptionAlgorithm.RSA_OAEP)
@@ -98,6 +106,14 @@ public class DefaultJWTParserTest {
         SecretKey secretKey = createSecretKey();
         String jwtString = Jwt.upn("jdoe@example.com").jwe().encrypt(secretKey);
         JsonWebToken jwt = new DefaultJWTParser().decrypt(jwtString, secretKey);
+        assertEquals("jdoe@example.com", jwt.getName());
+    }
+
+    @Test
+    public void testDecryptWithSecretString() throws Exception {
+        String secret = "AyM1SysPpbyDfgZld3umj1qzKObwVMko";
+        String jwtString = Jwt.upn("jdoe@example.com").jwe().encryptWithSecret(secret);
+        JsonWebToken jwt = new DefaultJWTParser().decrypt(jwtString, secret);
         assertEquals("jdoe@example.com", jwt.getName());
     }
 


### PR DESCRIPTION
Fixes #290. 

Quarkus users have to manually create `SecretKey` when they want to sign the token with a password so this PR adds a few shortcuts making it very easy to do.