### PR TITLE
Support for the configured secret key location

### DIFF
--- a/doc/modules/ROOT/pages/configuration.adoc
+++ b/doc/modules/ROOT/pages/configuration.adoc
@@ -31,6 +31,7 @@ Smallrye JWT supports many properties which can be used to customize the token p
 [cols="<m,<m,<2",options="header"]
 |===
 |Property Name|Default|Description
+|smallrye.jwt.verify.key.location|NONE|Location of the verification key which can point to both public and secret keys. Secret keys can only be in the JWK format. Note that 'mp.jwt.verify.publickey.location' will be ignored if this property is set.
 |smallrye.jwt.verify.algorithm|`RS256`|Signature algorithm. Set it to `ES256` to support the Elliptic Curve signature algorithm.
 |smallrye.jwt.verify.key-format|`ANY`|Set this property to a specific key format such as `PEM_KEY`, `PEM_CERTIFICATE`, `JWK` or `JWK_BASE64URL` to optimize the way the verification key is loaded.
 |smallrye.jwt.verify.relax-key-validation|false|Relax the validation of the verification keys, setting this property to `true` will allow public RSA keys with the length less than 2048 bit.

--- a/implementation/src/main/java/io/smallrye/jwt/auth/principal/AbstractKeyLocationResolver.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/principal/AbstractKeyLocationResolver.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import org.jose4j.jwk.HttpsJwks;
 import org.jose4j.jwk.JsonWebKey;
+import org.jose4j.jwk.OctetSequenceJsonWebKey;
 import org.jose4j.jwx.JsonWebStructure;
 import org.jose4j.lang.JoseException;
 import org.jose4j.lang.UnresolvableKeyException;
@@ -264,5 +265,12 @@ public class AbstractKeyLocationResolver {
             }
         }
         return jwk;
+    }
+
+    protected Key getSecretKeyFromJwk(JsonWebKey jwk) {
+        if (jwk instanceof OctetSequenceJsonWebKey) {
+            return ((OctetSequenceJsonWebKey) jwk).getKey();
+        }
+        return null;
     }
 }

--- a/implementation/src/main/java/io/smallrye/jwt/auth/principal/DecryptionKeyLocationResolver.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/principal/DecryptionKeyLocationResolver.java
@@ -69,10 +69,18 @@ public class DecryptionKeyLocationResolver extends AbstractKeyLocationResolver i
 
     private Key tryAsDecryptionJwk(JsonWebEncryption jwe) throws UnresolvableKeyException {
         JsonWebKey jwk = super.tryAsJwk(jwe, authContextInfo.getKeyEncryptionAlgorithm().getAlgorithm());
+        return fromJwkToDecryptionKey(jwk);
+    }
+
+    private Key fromJwkToDecryptionKey(JsonWebKey jwk) {
+        Key theKey = null;
         if (jwk != null) {
-            return PublicJsonWebKey.class.cast(jwk).getPrivateKey();
+            theKey = getSecretKeyFromJwk(jwk);
+            if (theKey == null) {
+                theKey = PublicJsonWebKey.class.cast(jwk).getPrivateKey();
+            }
         }
-        return null;
+        return theKey;
     }
 
     protected void initializeKeyContent() throws Exception {
@@ -94,9 +102,7 @@ public class DecryptionKeyLocationResolver extends AbstractKeyLocationResolver i
         }
         JsonWebKey jwk = loadFromJwk(content, authContextInfo.getTokenDecryptionKeyId(),
                 authContextInfo.getKeyEncryptionAlgorithm().getAlgorithm());
-        if (jwk != null) {
-            key = PublicJsonWebKey.class.cast(jwk).getPrivateKey();
-        }
+        key = fromJwkToDecryptionKey(jwk);
     }
 
     static PrivateKey tryAsPEMPrivateKey(String content) {

--- a/implementation/src/main/java/io/smallrye/jwt/auth/principal/KeyLocationResolver.java
+++ b/implementation/src/main/java/io/smallrye/jwt/auth/principal/KeyLocationResolver.java
@@ -68,10 +68,18 @@ public class KeyLocationResolver extends AbstractKeyLocationResolver implements 
 
     private Key tryAsVerificationJwk(JsonWebSignature jws) throws UnresolvableKeyException {
         JsonWebKey jwk = super.tryAsJwk(jws, authContextInfo.getSignatureAlgorithm().getAlgorithm());
+        return fromJwkToVerificationKey(jwk);
+    }
+
+    private Key fromJwkToVerificationKey(JsonWebKey jwk) {
+        Key theKey = null;
         if (jwk != null) {
-            return PublicJsonWebKey.class.cast(jwk).getPublicKey();
+            theKey = getSecretKeyFromJwk(jwk);
+            if (theKey == null) {
+                theKey = PublicJsonWebKey.class.cast(jwk).getPublicKey();
+            }
         }
-        return null;
+        return theKey;
     }
 
     protected void initializeKeyContent() throws Exception {
@@ -99,9 +107,7 @@ public class KeyLocationResolver extends AbstractKeyLocationResolver implements 
         }
         JsonWebKey jwk = loadFromJwk(content, authContextInfo.getTokenKeyId(),
                 authContextInfo.getSignatureAlgorithm().getAlgorithm());
-        if (jwk != null) {
-            key = PublicJsonWebKey.class.cast(jwk).getPublicKey();
-        }
+        key = fromJwkToVerificationKey(jwk);
     }
 
     static PublicKey tryAsPEMPublicKey(String content, SignatureAlgorithm algo) {

--- a/testsuite/basic/src/test/java/io/smallrye/jwt/auth/principal/KeyLocationResolverTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/jwt/auth/principal/KeyLocationResolverTest.java
@@ -21,6 +21,7 @@ import java.security.PrivateKey;
 import java.time.Instant;
 
 import org.eclipse.microprofile.jwt.tck.util.TokenUtils;
+import org.jose4j.jwt.JwtClaims;
 import org.jose4j.lang.InvalidAlgorithmException;
 import org.jose4j.lang.UnresolvableKeyException;
 import org.testng.Assert;
@@ -174,5 +175,16 @@ public class KeyLocationResolverTest {
         } catch (ParseException ex) {
             Assert.assertTrue(ex.getCause().getCause() instanceof InvalidAlgorithmException);
         }
+    }
+
+    @Test
+    public void testVerifyTokenSignedWithSecretKey() throws Exception {
+        String jwtString = Jwt.issuer("https://server.example.com").upn("Alice").sign("secretKey.jwk");
+        JWTAuthContextInfoProvider provider = JWTAuthContextInfoProvider.createWithSecretKeyLocation("secretKey.jwk",
+                "https://server.example.com");
+        JWTAuthContextInfo contextInfo = provider.getContextInfo();
+        contextInfo.setSignatureAlgorithm(SignatureAlgorithm.HS256);
+        JwtClaims jwt = new DefaultJWTTokenParser().parse(jwtString, contextInfo).getJwtClaims();
+        Assert.assertEquals("Alice", jwt.getClaimValueAsString("upn"));
     }
 }

--- a/testsuite/basic/src/test/resources/secretKey.jwk
+++ b/testsuite/basic/src/test/resources/secretKey.jwk
@@ -1,0 +1,4 @@
+{
+ "kty":"oct",
+ "k":"Fdh9u8rINxfivbrianbbVT1u232VQBZYKx1HGAGPt2I"
+ }


### PR DESCRIPTION
Fixes #126 
This is the final PR before the planned 2.2.1 release and resolves a long pending issue to do with configuring the symmetric key locations, with some good user interest around it. Now we'll have a comprehensive support for securing and validating JWT tokens with all sort of keys which will work well in a variety of cases.
PR itself is basic, I had to add a new property to avoid overloading the existing `publickey.location` one.