### PR TITLE
Correct letter case of SmallRye in documentation

### DIFF
--- a/doc/modules/ROOT/pages/configuration.adoc
+++ b/doc/modules/ROOT/pages/configuration.adoc
@@ -24,9 +24,9 @@ precedence:
 - JSON Web Key (JWK) or JSON Web Key Set (JWKS)
 - Base64 URL encoded JSON Web Key (JWK) or JSON Web Key Set (JWKS)
 
-== Smallrye JWT properties
+== SmallRye JWT properties
 
-Smallrye JWT supports many properties which can be used to customize the token processing:
+SmallRye JWT supports many properties which can be used to customize the token processing:
 
 [cols="<m,<m,<2",options="header"]
 |===
@@ -42,7 +42,7 @@ Smallrye JWT supports many properties which can be used to customize the token p
 |smallrye.jwt.token.schemes|`Bearer`|Comma-separated list containing an alternative single or multiple schemes, for example, `DPoP`.
 |smallrye.jwt.token.kid|none|Key identifier. If it is set then the verification JWK key as well every JWT token must have a matching `kid` header.
 |smallrye.jwt.time-to-live|none|The maximum number of seconds that a JWT may be issued for use. Effectively, the difference between the expiration date of the JWT and the issued at date must not exceed this value.
-|smallrye.jwt.require.named-principal|`false`|If an application relies on `java.security.Principal` returning a name then a token must have a `upn` or `preferred_username` or `sub` claim set. Setting this property will result in Smallrye JWT throwing an exception if none of these claims is available for the application code to reliably deal with a non-null `Principal` name.
+|smallrye.jwt.require.named-principal|`false`|If an application relies on `java.security.Principal` returning a name then a token must have a `upn` or `preferred_username` or `sub` claim set. Setting this property will result in SmallRye JWT throwing an exception if none of these claims is available for the application code to reliably deal with a non-null `Principal` name.
 |smallrye.jwt.path.sub|none|Path to the claim containing the subject name. It starts from the top level JSON object and can contain multiple segments where each segment represents a JSON object name only, example: `realms/subject`. This property can be used if a token has no 'sub' claim but has the subject set in a different claim. Use double quotes with the namespace qualified claims.
 |smallrye.jwt.claims.sub|none| This property can be used to set a default sub claim value when the current token has no standard or custom `sub` claim available. Effectively this property can be used to customize `java.security.Principal` name if no `upn` or `preferred_username` or `sub` claim is set.
 |smallrye.jwt.path.groups|none|Path to the claim containing the groups. It starts from the top level JSON object and can contain multiple segments where each segment represents a JSON object name only, example: `realm/groups`. This property can be used if a token has no 'groups' claim but has the groups set in a different claim. Use double quotes with the namespace qualified claims.


### PR DESCRIPTION
As a follow-up to https://github.com/quarkusio/quarkus/issues/13091
this commit fixes the case of SmallRye in .
This is useful for Quarkus as it allows copy-and-pasting the relevant
section to the Quarkus JWT guide.