### PR TITLE
Better handling of the wrong JWT build key locations

### DIFF
--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/ImplMessages.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/ImplMessages.java
@@ -35,11 +35,11 @@ interface ImplMessages {
     @Message(id = 5006, value = "Unsupported content encryption algorithm: %s")
     JwtEncryptionException unsupportedContentEncryptionAlgorithm(String algorithmName);
 
-    @Message(id = 5007, value = "Key encrypting key can not be loaded from: %s")
-    JwtEncryptionException encryptionKeyNotFound(String keyLocation);
+    @Message(id = 5007, value = "Key encryption key can not be loaded from: %s")
+    IllegalArgumentException encryptionKeyCanNotBeLoadedFromLocation(String keyLocation);
 
     @Message(id = 5008, value = "Please set a 'smallrye.jwt.encrypt.key-location' property")
-    JwtEncryptionException keyLocationPropertyEmpty();
+    IllegalArgumentException encryptionKeyLocationNotConfigured();
 
     @Message(id = 5009, value = "")
     JwtSignatureException signatureException(@Cause Throwable throwable);
@@ -93,4 +93,7 @@ interface ImplMessages {
     @Message(id = 5026, value = "Failure to read the json content from %s: %s")
     JwtException failureToReadJsonContentFromJsonResName(String jsonResName, String exceptionMessage,
             @Cause Throwable throwable);
+
+    @Message(id = 5027, value = "")
+    JwtEncryptionException encryptionException(@Cause Throwable throwable);
 }

--- a/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtEncryptTest.java
+++ b/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtEncryptTest.java
@@ -16,6 +16,9 @@
  */
 package io.smallrye.jwt.build;
 
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.security.KeyPairGenerator;
@@ -227,6 +230,16 @@ public class JwtEncryptTest {
 
         JwtClaims claims = JwtClaims.parse(jwe.getPlaintextString());
         checkJwtClaims(claims);
+    }
+
+    @Test
+    public void testEncryptWithInvalidKeyLocation() throws Exception {
+        JwtClaimsBuilder builder = Jwt.claims();
+
+        JwtEncryptionException thrown = assertThrows("JwtEncryptionException is expected",
+                JwtEncryptionException.class, () -> builder.jwe().encrypt("/invalid-key-location.pem"));
+        assertTrue(thrown.getCause()
+                .getMessage().contains("Key encryption key can not be loaded from: /invalid-key-location.pem"));
     }
 
     private static PrivateKey getPrivateKey() throws Exception {

--- a/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtSignTest.java
+++ b/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtSignTest.java
@@ -16,6 +16,9 @@
  */
 package io.smallrye.jwt.build;
 
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
@@ -239,6 +242,16 @@ public class JwtSignTest {
         checkDefaultClaimsAndHeaders(getJwsHeaders(jwt, 2), claims);
 
         Assert.assertEquals("custom-value", claims.getClaimValue("customClaim"));
+    }
+
+    @Test
+    public void testSignWithInvalidKeyLocation() throws Exception {
+        JwtClaimsBuilder builder = Jwt.claims();
+
+        JwtSignatureException thrown = assertThrows("JwtSignatureException is expected",
+                JwtSignatureException.class, () -> builder.sign("/invalid-key-location.pem"));
+        assertTrue(thrown.getCause()
+                .getMessage().contains("Signing key can not be loaded from: /invalid-key-location.pem"));
     }
 
     @Test


### PR DESCRIPTION
Fixes #327 

The NPE reported at the StackOverflow page is to do with the key being null, so this PR ensures it won't happen again and makes it consistent between the signature and encryption implementations.

Also the key format in that issue is PKCS12 which is not currently supported - perhaps we can do it in 3.0.0

I'd like to release 2.4.0 after this PR is reviewed/merged