### PR TITLE
Use UUID for the 'jti' claim, and update ResourceUtils to have a separate InputStream utility

### DIFF
--- a/implementation/common/src/main/java/io/smallrye/jwt/util/ResourceUtils.java
+++ b/implementation/common/src/main/java/io/smallrye/jwt/util/ResourceUtils.java
@@ -41,6 +41,28 @@ public final class ResourceUtils {
 
     public static String readResource(String resourceLocation, UrlStreamResolver urlResolver) throws IOException {
 
+        InputStream is = getResourceStream(resourceLocation, urlResolver);
+
+        if (is == null) {
+            return null;
+        }
+
+        StringWriter contents = new StringWriter();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(is))) {
+            String line = null;
+            while ((line = reader.readLine()) != null) {
+                contents.write(line);
+            }
+        }
+        return contents.toString();
+    }
+
+    public static InputStream getResourceStream(String resourceLocation) throws IOException {
+        return getResourceStream(resourceLocation, null);
+    }
+
+    public static InputStream getResourceStream(String resourceLocation, UrlStreamResolver urlResolver) throws IOException {
+
         InputStream is = null;
 
         if (resourceLocation.startsWith(HTTP_BASED_SCHEME)) {
@@ -60,18 +82,7 @@ public final class ResourceUtils {
             }
         }
 
-        if (is == null) {
-            return null;
-        }
-
-        StringWriter contents = new StringWriter();
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(is))) {
-            String line = null;
-            while ((line = reader.readLine()) != null) {
-                contents.write(line);
-            }
-        }
-        return contents.toString();
+        return is;
     }
 
     public static UrlStreamResolver getUrlResolver() {

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtBuildUtils.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtBuildUtils.java
@@ -2,6 +2,7 @@ package io.smallrye.jwt.build.impl;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
 
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.jwt.Claims;
@@ -27,7 +28,7 @@ public class JwtBuildUtils {
         }
         setExpiryClaim(claims);
         if (!claims.hasClaim(Claims.jti.name())) {
-            claims.setGeneratedJwtId();
+            claims.setClaim(Claims.jti.name(), UUID.randomUUID().toString());
         }
         if (!claims.hasClaim(Claims.iss.name())) {
             String issuer = getConfigProperty("smallrye.jwt.new-token.issuer", String.class);


### PR DESCRIPTION
Fixes #344 

Also, minor refactoring of ResourceUtils to be able to use the utility code which gets the stream only, without converting it to String, realized it can be handy while I was coding some KeyStore.load 