### PR TITLE
Support for expireIn build method and other minor cleanup

### DIFF
--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/JwtClaimsBuilder.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/JwtClaimsBuilder.java
@@ -1,5 +1,6 @@
 package io.smallrye.jwt.build;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.Map;
@@ -81,19 +82,37 @@ public interface JwtClaimsBuilder extends JwtSignature {
     /**
      * Set an expiry 'exp' claim
      * 
-     * @param expiredAt the expiry time in seconds
+     * @param expiresAt the absolute expiry time in seconds
      * @return JwtClaimsBuilder
      */
-    JwtClaimsBuilder expiresAt(long expiredAt);
+    JwtClaimsBuilder expiresAt(long expiresAt);
 
     /**
      * Set an expiry 'exp' claim
      * 
-     * @param expiredAt the expiry time in seconds
+     * @param expiresAt the absolute expiry time in seconds
      * @return JwtClaimsBuilder
      */
-    default JwtClaimsBuilder expiresAt(Instant expiredAt) {
-        return expiresAt(expiredAt.getEpochSecond());
+    default JwtClaimsBuilder expiresAt(Instant expiresAt) {
+        return expiresAt(expiresAt.getEpochSecond());
+    }
+
+    /**
+     * Set an expiry 'exp' claim
+     * 
+     * @param expiresIn the relative expiry time in seconds which will be added to the issuedAt time
+     * @return JwtClaimsBuilder
+     */
+    JwtClaimsBuilder expiresIn(long expiresIn);
+
+    /**
+     * Set an expiry 'exp' claim
+     * 
+     * @param expiresIn the relative expiry duration which will be converted to seconds and added to the issuedAt time
+     * @return JwtClaimsBuilder
+     */
+    default JwtClaimsBuilder expiresIn(Duration expiresIn) {
+        return expiresIn(expiresIn.getSeconds());
     }
 
     /**

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtClaimsBuilderImpl.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtClaimsBuilderImpl.java
@@ -128,8 +128,17 @@ class JwtClaimsBuilderImpl extends JwtSignatureImpl implements JwtClaimsBuilder,
      * {@inheritDoc}
      */
     @Override
-    public JwtClaimsBuilder expiresAt(long expiredAt) {
-        claims.setExpirationTime(NumericDate.fromSeconds(expiredAt));
+    public JwtClaimsBuilder expiresAt(long expiresAt) {
+        claims.setExpirationTime(NumericDate.fromSeconds(expiresAt));
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public JwtClaimsBuilder expiresIn(long expiresIn) {
+        tokenLifespan = expiresIn;
         return this;
     }
 
@@ -146,7 +155,7 @@ class JwtClaimsBuilderImpl extends JwtSignatureImpl implements JwtClaimsBuilder,
      */
     @Override
     public JwtClaimsBuilder groups(Set<String> groups) {
-        claims.setClaim("groups", groups.stream().collect(Collectors.toList()));
+        claims.setClaim(Claims.groups.name(), groups.stream().collect(Collectors.toList()));
         return this;
     }
 
@@ -236,7 +245,7 @@ class JwtClaimsBuilderImpl extends JwtSignatureImpl implements JwtClaimsBuilder,
      */
     @Override
     public String json() {
-        JwtBuildUtils.setDefaultJwtClaims(claims);
+        JwtBuildUtils.setDefaultJwtClaims(claims, tokenLifespan);
         return claims.toJson();
     }
 
@@ -245,7 +254,7 @@ class JwtClaimsBuilderImpl extends JwtSignatureImpl implements JwtClaimsBuilder,
      */
     @Override
     public JwtEncryptionBuilder jwe() {
-        JwtBuildUtils.setDefaultJwtClaims(claims);
+        JwtBuildUtils.setDefaultJwtClaims(claims, tokenLifespan);
         return new JwtEncryptionImpl(claims.toJson());
     }
 

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtSignatureImpl.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtSignatureImpl.java
@@ -28,6 +28,7 @@ import io.smallrye.jwt.util.KeyUtils;
 class JwtSignatureImpl implements JwtSignature {
     JwtClaims claims = new JwtClaims();
     Map<String, Object> headers = new HashMap<>();
+    Long tokenLifespan;
 
     JwtSignatureImpl() {
     }
@@ -145,7 +146,7 @@ class JwtSignatureImpl implements JwtSignature {
     }
 
     private String signInternal(Key signingKey) {
-        JwtBuildUtils.setDefaultJwtClaims(claims);
+        JwtBuildUtils.setDefaultJwtClaims(claims, tokenLifespan);
         JsonWebSignature jws = new JsonWebSignature();
         for (Map.Entry<String, Object> entry : headers.entrySet()) {
             jws.setHeader(entry.getKey(), entry.getValue());

--- a/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtSignTest.java
+++ b/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtSignTest.java
@@ -25,6 +25,7 @@ import java.security.Key;
 import java.security.KeyPairGenerator;
 import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
@@ -121,9 +122,34 @@ public class JwtSignTest {
     }
 
     @Test
-    public void testCustomIssuedAtExpiresAt() throws Exception {
+    public void testCustomIssuedAtExpiresAtLong() throws Exception {
+        Instant now = Instant.now();
+        String jwt = Jwt.claims().issuedAt(now).expiresAt(now.getEpochSecond() + 3000).sign();
+        verifyJwtCustomIssuedAtExpiresAt(now, jwt);
+    }
+
+    @Test
+    public void testCustomIssuedAtExpiresAtInstant() throws Exception {
         Instant now = Instant.now();
         String jwt = Jwt.claims().issuedAt(now).expiresAt(now.plusSeconds(3000)).sign();
+        verifyJwtCustomIssuedAtExpiresAt(now, jwt);
+    }
+
+    @Test
+    public void testCustomIssuedAtExpiresInLong() throws Exception {
+        Instant now = Instant.now();
+        String jwt = Jwt.claims().issuedAt(now).expiresIn(3000).sign();
+        verifyJwtCustomIssuedAtExpiresAt(now, jwt);
+    }
+
+    @Test
+    public void testCustomIssuedAtExpiresInDuration() throws Exception {
+        Instant now = Instant.now();
+        String jwt = Jwt.claims().issuedAt(now).expiresIn(Duration.ofSeconds(3000)).sign();
+        verifyJwtCustomIssuedAtExpiresAt(now, jwt);
+    }
+
+    private void verifyJwtCustomIssuedAtExpiresAt(Instant now, String jwt) throws Exception {
         JsonWebSignature jws = new JsonWebSignature();
         jws.setKey(KeyUtils.readPublicKey("/publicKey.pem"));
         jws.setCompactSerialization(jwt);


### PR DESCRIPTION
This PR adds `expiresIn` helper to set the `exp` claim which should make it much easier to set the custom expiry claim as opposed to the users having to manually add the lifespan to the current issued time. Plus some minor cleanup