### PR TITLE
Issue#372 Status code should be 500 when public key cannot be resolved

### DIFF
--- a/implementation/jwt-auth/src/main/java/io/smallrye/jwt/auth/mechanism/MechanismLogging.java
+++ b/implementation/jwt-auth/src/main/java/io/smallrye/jwt/auth/mechanism/MechanismLogging.java
@@ -22,4 +22,8 @@ interface MechanismLogging extends BasicLogger {
     @LogMessage(level = Logger.Level.DEBUG)
     @Message(id = 11002, value = "No usable bearer token was found in the request, continuing unauthenticated")
     void noUsableBearerTokenFound();
+
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 11003, value = "Failed to resolve the public key. Either corrupt or unavailable.")
+    void noUsableKey();
 }


### PR DESCRIPTION
Fixes #372 

Currently, exception handling in `JWTHTTPAuthenticationMechanism` issues status code 401 when the public key is corrupted or unavailable. 