### PR TITLE
Report UnresolvableKeyException in the inner-sign/decrypt case, update JAX-RS filter too

### DIFF
--- a/implementation/jwt-auth/src/main/java/io/smallrye/jwt/auth/jaxrs/JAXRSLogging.java
+++ b/implementation/jwt-auth/src/main/java/io/smallrye/jwt/auth/jaxrs/JAXRSLogging.java
@@ -16,18 +16,22 @@ interface JAXRSLogging extends BasicLogger {
     void success();
 
     @LogMessage(level = Logger.Level.DEBUG)
-    @Message(id = 10001, value = "Unable to parse/validate JWT")
-    void unableParseJWT(@Cause Throwable throwable);
+    @Message(id = 10001, value = "Unable to validate bearer token")
+    void unableToValidateBearerToken(@Cause Throwable throwable);
 
     @LogMessage(level = Logger.Level.DEBUG)
-    @Message(id = 10002, value = "EE Security is not in use, %s has been registered")
+    @Message(id = 10002, value = "Failed to resolve the key. Either corrupt or unavailable.")
+    void noUsableKey();
+
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 10003, value = "EE Security is not in use, %s has been registered")
     void eeSecurityNotInUseButRegistered(String authenticationFilterName);
 
     @LogMessage(level = Logger.Level.DEBUG)
-    @Message(id = 10003, value = "MP-JWT LoginConfig present, %s is enabled")
+    @Message(id = 10004, value = "MP-JWT LoginConfig present, %s is enabled")
     void mpJWTLoginConfigPresent(String className);
 
     @LogMessage(level = Logger.Level.INFO)
-    @Message(id = 10004, value = "LoginConfig not found on Application class, %s will not be enabled")
+    @Message(id = 10005, value = "LoginConfig not found on Application class, %s will not be enabled")
     void mpJWTLoginConfigNotFound(String className);
 }

--- a/implementation/jwt-auth/src/main/java/io/smallrye/jwt/auth/mechanism/JWTHttpAuthenticationMechanism.java
+++ b/implementation/jwt-auth/src/main/java/io/smallrye/jwt/auth/mechanism/JWTHttpAuthenticationMechanism.java
@@ -35,6 +35,7 @@ import io.smallrye.jwt.auth.AbstractBearerTokenExtractor;
 import io.smallrye.jwt.auth.cdi.PrincipalProducer;
 import io.smallrye.jwt.auth.principal.JWTAuthContextInfo;
 import io.smallrye.jwt.auth.principal.JWTParser;
+import io.smallrye.jwt.auth.principal.ParseException;
 
 /**
  * A JAX-RS HttpAuthenticationMechanism prototype
@@ -79,7 +80,7 @@ public class JWTHttpAuthenticationMechanism implements HttpAuthenticationMechani
                 Set<String> groups = jwtPrincipal.getGroups();
                 MechanismLogging.log.success();
                 return httpMessageContext.notifyContainerAboutLogin(jwtPrincipal, groups);
-            } catch (Exception e) {
+            } catch (ParseException e) {
                 if (e.getCause() instanceof UnresolvableKeyException) {
                     MechanismLogging.log.noUsableKey();
                     return reportInternalError(httpMessageContext);
@@ -87,6 +88,9 @@ public class JWTHttpAuthenticationMechanism implements HttpAuthenticationMechani
                     MechanismLogging.log.unableToValidateBearerToken(e);
                     return httpMessageContext.responseUnauthorized();
                 }
+            } catch (Exception e) {
+                MechanismLogging.log.unableToValidateBearerToken(e);
+                return reportInternalError(httpMessageContext);
             }
         } else {
             MechanismLogging.log.noUsableBearerTokenFound();

--- a/implementation/jwt-auth/src/main/java/io/smallrye/jwt/auth/mechanism/MechanismLogging.java
+++ b/implementation/jwt-auth/src/main/java/io/smallrye/jwt/auth/mechanism/MechanismLogging.java
@@ -24,6 +24,6 @@ interface MechanismLogging extends BasicLogger {
     void noUsableBearerTokenFound();
 
     @LogMessage(level = Logger.Level.DEBUG)
-    @Message(id = 11003, value = "Failed to resolve the public key. Either corrupt or unavailable.")
+    @Message(id = 11003, value = "Failed to resolve the key. Either corrupt or unavailable.")
     void noUsableKey();
 }

--- a/implementation/jwt-auth/src/main/java/io/smallrye/jwt/auth/principal/DefaultJWTTokenParser.java
+++ b/implementation/jwt-auth/src/main/java/io/smallrye/jwt/auth/principal/DefaultJWTTokenParser.java
@@ -86,10 +86,10 @@ public class DefaultJWTTokenParser {
             return jwe.getPlaintextString();
         } catch (UnresolvableKeyException e) {
             PrincipalLogging.log.decryptionKeyUnresolvable();
-            throw PrincipalMessages.msg.decryptionKeyUnresolvable();
+            throw PrincipalMessages.msg.decryptionKeyUnresolvable(e);
         } catch (JoseException e) {
             PrincipalLogging.log.encryptedTokenSequenceInvalid();
-            throw PrincipalMessages.msg.encryptedTokenSequenceInvalid();
+            throw PrincipalMessages.msg.encryptedTokenSequenceInvalid(e);
         }
     }
 

--- a/implementation/jwt-auth/src/main/java/io/smallrye/jwt/auth/principal/PrincipalMessages.java
+++ b/implementation/jwt-auth/src/main/java/io/smallrye/jwt/auth/principal/PrincipalMessages.java
@@ -55,10 +55,10 @@ interface PrincipalMessages {
     ParseException verificationKeyUnresolvable();
 
     @Message(id = 7012, value = "Decryption key is unresolvable")
-    ParseException decryptionKeyUnresolvable();
+    ParseException decryptionKeyUnresolvable(@Cause Throwable throwable);
 
     @Message(id = 7013, value = "Encrypted token sequence is invalid")
-    ParseException encryptedTokenSequenceInvalid();
+    ParseException encryptedTokenSequenceInvalid(@Cause Throwable throwable);
 
     @Message(id = 7014, value = "Failed to load X509 certificates")
     ParseException failedToLoadCertificates();


### PR DESCRIPTION
@MikeEdgar - have a look please - I've also updated the JAX-RS filter 

@SoniaZaldana FYI, I also had to update the `MechanismLogging.noUsableKey` log message a tiny bit, dropped `...public...` in the key description - it can also be a private decryption key (standard from MP JWT 1.2) or a symmetric key (supported at the smallrye-jwt level only). I think we can improve it further down the line with the key type specific exceptions as well...
You are also welcome to review (I'll be able to request a review when you become a committer )

By the way, for 3.0.0, I think moving the http mechanism into its own module would be the right idea :-) as the core module would better be transport agnostic; similarly to how the jaxrs code got moved into its own module

Thanks