### PR TITLE
Add a smallrye.jwt.new-token.audience property

### DIFF
--- a/doc/modules/ROOT/pages/generate-jwt.adoc
+++ b/doc/modules/ROOT/pages/generate-jwt.adoc
@@ -144,4 +144,5 @@ Smallrye JWT supports the following properties which can be used to customize th
 |smallrye.jwt.sign.key-location|none|Location of a key which will be used to sign the claims when either a no-argument sign() or innerSign() method is called.
 |smallrye.jwt.new-token.lifespan|300|Token lifespan in seconds which will be used to calculate an `exp` (expiry) claim value if this claim has not already been set.
 |smallrye.jwt.new-token.issuer|none|Token issuer which can be used to set an `iss` (issuer) claim value if this claim has not already been set.
+|smallrye.jwt.new-token.audience|none|Token audience which can be used to set an `aud` (audience) claim value if this claim has not already been set.
 |===

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/JwtClaimsBuilder.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/JwtClaimsBuilder.java
@@ -20,8 +20,9 @@ import javax.json.JsonObject;
  * lifespan value of 5 minutes to the 'iat' claim value. The 'smallrye.jwt.new-token.lifespan' property can be used to
  * customize a new token lifespan and its 'exp' claim values.
  * <p>
- * JwtClaimsBuilder implementations must set the 'iss' (issuer) claim if has not already been set and
- * the 'smallrye.jwt.new-token.issuer' property is set.
+ * The 'iss' (issuer) claim must be set if it has not already been set and the 'smallrye.jwt.new-token.issuer' property is set.
+ * The 'aud' (audience) claim must be set if it has not already been set and the 'smallrye.jwt.new-token.audience' property is
+ * set.
  * <p>
  * Note that JwtClaimsBuilder implementations are not expected to be thread-safe.
  * 

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtBuildUtils.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtBuildUtils.java
@@ -35,6 +35,12 @@ public class JwtBuildUtils {
                 claims.setIssuer(issuer);
             }
         }
+        if (!claims.hasClaim(Claims.aud.name())) {
+            String audience = getConfigProperty("smallrye.jwt.new-token.audience", String.class);
+            if (audience != null) {
+                claims.setAudience(audience);
+            }
+        }
     }
 
     static <T> T getConfigProperty(String name, Class<T> cls) {

--- a/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtBuildConfigSource.java
+++ b/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtBuildConfigSource.java
@@ -10,6 +10,7 @@ public class JwtBuildConfigSource implements ConfigSource {
     boolean signingKeyAvailable = true;
     boolean lifespanPropertyRequired;
     boolean issuerPropertyRequired;
+    boolean audiencePropertyRequired;
     String encryptionKeyLocation = "/publicKey.pem";
     String signingKeyLocation = "/privateKey.pem";
 
@@ -25,6 +26,9 @@ public class JwtBuildConfigSource implements ConfigSource {
         }
         if (issuerPropertyRequired) {
             map.put("smallrye.jwt.new-token.issuer", "https://custom-issuer");
+        }
+        if (audiencePropertyRequired) {
+            map.put("smallrye.jwt.new-token.audience", "https://custom-audience");
         }
         return map;
     }
@@ -57,5 +61,9 @@ public class JwtBuildConfigSource implements ConfigSource {
 
     public void setIssuerPropertyRequired(boolean issuerPropertyRequired) {
         this.issuerPropertyRequired = issuerPropertyRequired;
+    }
+
+    public void setAudiencePropertyRequired(boolean audiencePropertyRequired) {
+        this.audiencePropertyRequired = audiencePropertyRequired;
     }
 }


### PR DESCRIPTION
Fixes #364

This PR adds a new `smallrye.jwt.new-token.audience` property - for the users be able to avoid setting the `technical` claims like `aud` (similarly to how it has already been done with `iss`) 