### PR TITLE
Remove Optional for the config properties with the default values

### DIFF
--- a/implementation/jwt-auth/src/main/java/io/smallrye/jwt/SmallryeJwtUtils.java
+++ b/implementation/jwt-auth/src/main/java/io/smallrye/jwt/SmallryeJwtUtils.java
@@ -66,13 +66,11 @@ public class SmallryeJwtUtils {
         }
     }
 
-    public static void setTokenSchemes(JWTAuthContextInfo contextInfo, Optional<String> tokenSchemes) {
-        if (tokenSchemes.isPresent()) {
-            final List<String> schemes = new ArrayList<>();
-            for (final String s : tokenSchemes.get().split(",")) {
-                schemes.add(s.trim());
-            }
-            contextInfo.setTokenSchemes(schemes);
+    public static void setTokenSchemes(JWTAuthContextInfo contextInfo, String tokenSchemes) {
+        final List<String> schemes = new ArrayList<>();
+        for (final String s : tokenSchemes.split(",")) {
+            schemes.add(s.trim());
         }
+        contextInfo.setTokenSchemes(schemes);
     }
 }


### PR DESCRIPTION
This is the last PR which I'd like to target at the `mpjwt12` branch. It updates `JwtAuthContextInfoProvider` and:
- removes `Optional` where possible (Mike - thanks for pointing it earlier on)
- removes the redundant getters - they do not even cover all the properties - they were originally intended for Thorntail and even there there were not property integrated as far as I recall
- drops the deprecated property which has already been deprecated in the `2.x` line