### PR TITLE
Enforce types of the directly supported claims when they are set as Objects

### DIFF
--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/Jwt.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/Jwt.java
@@ -1,5 +1,6 @@
 package io.smallrye.jwt.build;
 
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
@@ -7,6 +8,7 @@ import java.util.Set;
 import javax.json.JsonArray;
 import javax.json.JsonObject;
 
+import org.eclipse.microprofile.jwt.Claims;
 import org.eclipse.microprofile.jwt.JsonWebToken;
 
 import io.smallrye.jwt.build.spi.JwtProvider;
@@ -100,9 +102,46 @@ public final class Jwt {
     /**
      * Creates a new instance of {@link JwtClaimsBuilder} with a specified claim.
      *
+     * Simple claim value are converted to {@link String} unless it is an instance of {@link Boolean}, {@link Number} or
+     * {@link Instant}. {@link Instant} values have their number of seconds from the epoch converted to long.
+     *
+     * Array claims can be set as {@link Collection} or {@link JsonArray}, complex claims can be set as {@link Map} or
+     * {@link JsonObject}. The members of the array claims can be complex claims.
+     *
+     * Types of the claims directly supported by this builder are enforced.
+     * The 'iss' (issuer), 'sub' (subject), 'upn', 'preferred_username' and 'jti' (token identifier) claims must be of
+     * {@link String} type.
+     * The 'aud' (audience) and 'groups' claims must be either of {@link String} or {@link Collection} of {@link String} type.
+     * The 'iat' (issued at) and 'exp' (expires at) claims must be either of long or {@link Instant} type.
+     *
      * @param name the claim name
      * @param value the claim value
-     * @return {@link JwtClaimsBuilder}
+     * @throws IllegalArgumentException - if the type of the claim directly supported by {@link JwtClaimsBuilder} is wrong
+     * @return JwtClaimsBuilder
+     */
+    public static JwtClaimsBuilder claim(Claims name, Object value) {
+        return claims().claim(name, value);
+    }
+
+    /**
+     * Creates a new instance of {@link JwtClaimsBuilder} with a specified claim.
+     *
+     * Simple claim value are converted to {@link String} unless it is an instance of {@link Boolean}, {@link Number} or
+     * {@link Instant}. {@link Instant} values have their number of seconds from the epoch converted to long.
+     *
+     * Array claims can be set as {@link Collection} or {@link JsonArray}, complex claims can be set as {@link Map} or
+     * {@link JsonObject}. The members of the array claims can be complex claims.
+     *
+     * Types of the claims directly supported by this builder are enforced.
+     * The 'iss' (issuer), 'sub' (subject), 'upn', 'preferred_username' and 'jti' (token identifier) claims must be of
+     * {@link String} type.
+     * The 'aud' (audience) and 'groups' claims must be either of {@link String} or {@link Collection} of {@link String} type.
+     * The 'iat' (issued at) and 'exp' (expires at) claims must be either of long or {@link Instant} type.
+     *
+     * @param name the claim name
+     * @param value the claim value
+     * @throws IllegalArgumentException - if the type of the claim directly supported by {@link JwtClaimsBuilder} is wrong
+     * @return JwtClaimsBuilder
      */
     public static JwtClaimsBuilder claim(String name, Object value) {
         return claims().claim(name, value);

--- a/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtClaimTypeVerifierTest.java
+++ b/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtClaimTypeVerifierTest.java
@@ -1,0 +1,110 @@
+/*
+ *   Copyright 2021 Red Hat, Inc, and individual contributors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package io.smallrye.jwt.build;
+
+import static org.junit.Assert.assertThrows;
+
+import java.time.Instant;
+import java.util.Arrays;
+
+import javax.json.Json;
+
+import org.eclipse.microprofile.jwt.Claims;
+import org.junit.Test;
+
+public class JwtClaimTypeVerifierTest {
+
+    @Test
+    public void testSub() {
+        Jwt.claim(Claims.sub, "1");
+        assertThrows("IllegalArgumentException is expected", IllegalArgumentException.class,
+                () -> Jwt.claim(Claims.sub, 1));
+    }
+
+    @Test
+    public void testIss() {
+        Jwt.claim(Claims.iss, "1");
+        assertThrows("IllegalArgumentException is expected", IllegalArgumentException.class,
+                () -> Jwt.claim(Claims.iss, 1));
+    }
+
+    @Test
+    public void testUpn() {
+        Jwt.claim(Claims.upn, "1");
+        assertThrows("IllegalArgumentException is expected", IllegalArgumentException.class,
+                () -> Jwt.claim(Claims.upn, 1));
+    }
+
+    @Test
+    public void testJti() {
+        Jwt.claim(Claims.jti, "1");
+        assertThrows("IllegalArgumentException is expected", IllegalArgumentException.class,
+                () -> Jwt.claim(Claims.jti, 1));
+    }
+
+    @Test
+    public void testPreferredUserName() {
+        Jwt.claim(Claims.preferred_username, "1");
+        assertThrows("IllegalArgumentException is expected", IllegalArgumentException.class,
+                () -> Jwt.claim(Claims.preferred_username, 1));
+    }
+
+    @Test
+    public void testIat() {
+        Jwt.claim(Claims.iat, Instant.now().getEpochSecond());
+        Jwt.claim(Claims.iat, Instant.now());
+        assertThrows("IllegalArgumentException is expected", IllegalArgumentException.class,
+                () -> Jwt.claim(Claims.iat, "1"));
+    }
+
+    @Test
+    public void testExp() {
+        Jwt.claim(Claims.exp, Instant.now().getEpochSecond());
+        Jwt.claim(Claims.exp, Instant.now());
+        assertThrows("IllegalArgumentException is expected", IllegalArgumentException.class,
+                () -> Jwt.claim(Claims.exp, "1"));
+    }
+
+    @Test
+    public void testAud() {
+        Jwt.claim(Claims.aud, "1");
+        Jwt.claim(Claims.aud, Arrays.asList("1"));
+        Jwt.claim(Claims.aud, Json.createArrayBuilder().add("1").build());
+        assertThrows("IllegalArgumentException is expected", IllegalArgumentException.class,
+                () -> Jwt.claim(Claims.aud, 1));
+        assertThrows("IllegalArgumentException is expected", IllegalArgumentException.class,
+                () -> Jwt.claim(Claims.aud,
+                        Arrays.asList(1)));
+        assertThrows("IllegalArgumentException is expected", IllegalArgumentException.class,
+                () -> Jwt.claim(Claims.aud, Json.createArrayBuilder().add(1).build()));
+    }
+
+    @Test
+    public void testGroups() {
+        Jwt.claim(Claims.groups, "1");
+        Jwt.claim(Claims.groups, Arrays.asList("1"));
+        Jwt.claim(Claims.groups, Json.createArrayBuilder().add("1").build());
+        assertThrows("IllegalArgumentException is expected", IllegalArgumentException.class,
+                () -> Jwt.claim(Claims.groups, 1));
+        assertThrows("IllegalArgumentException is expected", IllegalArgumentException.class,
+                () -> Jwt.claim(Claims.groups,
+                        Arrays.asList(1)));
+        assertThrows("IllegalArgumentException is expected", IllegalArgumentException.class,
+                () -> Jwt.claim(Claims.groups, Json.createArrayBuilder().add(1).build()));
+    }
+
+}


### PR DESCRIPTION
Fixes #391

I've been thinking for a while what exactly would be the right course of action when someone types `.claim("sub", 1)` and decided that instead of silently converting to String and causing some potentially difficult to diagnose problems it would be better to enforce the correct types for only those claims which are well-known (ex JWT and Mp JWT specs) but more importantly those which are directly (have the dedicated setters) supported by this API - this will also ensure the consistent handling of such claims, whether they set in a typed way or as Objects.

A few simple claims must be Strings, `aud` or `groups` - Strings or Collections of Strings, `iat` and `exp` - `long` or `Instant`.

Also improved the documentation. And added `claim` setters accepting `Claims` as a claim name