### PR TITLE
Fix configuration key location inconsistency and deprecate the inner-sign none signatures

### DIFF
--- a/doc/modules/ROOT/pages/generate-jwt.adoc
+++ b/doc/modules/ROOT/pages/generate-jwt.adoc
@@ -140,8 +140,10 @@ Smallrye JWT supports the following properties which can be used to customize th
 [cols="<m,<m,<2",options="header"]
 |===
 |Property Name|Default|Description
-|smallrye.jwt.encrypt.key-location|none|Location of a key which will be used to encrypt the claims or inner JWT when a no-argument encrypt() method is called.
-|smallrye.jwt.sign.key-location|none|Location of a key which will be used to sign the claims when either a no-argument sign() or innerSign() method is called.
+|smallrye.jwt.encrypt.key.location|none|Location of a key which will be used to encrypt the claims or inner JWT when a no-argument encrypt() method is called.
+|smallrye.jwt.encrypt.key-location|none|Location of a key which will be used to encrypt the claims or inner JWT when a no-argument encrypt() method is called. This property is deprecated and will be removed in the next major release.
+|smallrye.jwt.sign.key.location|none|Location of a key which will be used to sign the claims when either a no-argument sign() or innerSign() method is called.
+|smallrye.jwt.sign.key-location|none|Location of a key which will be used to sign the claims when either a no-argument sign() or innerSign() method is called. This property is deprecated and will be removed in the next major release.
 |smallrye.jwt.new-token.lifespan|300|Token lifespan in seconds which will be used to calculate an `exp` (expiry) claim value if this claim has not already been set.
 |smallrye.jwt.new-token.issuer|none|Token issuer which can be used to set an `iss` (issuer) claim value if this claim has not already been set.
 |smallrye.jwt.new-token.audience|none|Token audience which can be used to set an `aud` (audience) claim value if this claim has not already been set.

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/JwtEncryption.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/JwtEncryption.java
@@ -57,7 +57,10 @@ public interface JwtEncryption {
 
     /**
      * Encrypt the claims or inner JWT with a key loaded from the location set with the
-     * "smallrye.jwt.encrypt.key-location" property.
+     * "smallrye.jwt.encrypt.key-location" or "smallrye.jwt.encrypt.key.location" properties.
+     * 
+     * Note: "smallrye.jwt.encrypt.key-location" property is deprecated and will be removed in the next major release.
+     * 
      * 'RSA-OAEP-256', 'ECDH-ES+A256KW' and 'A256KW' key encryption algorithms will be used by default
      * when public RSA, EC or secret keys are used unless a different one has been set with {@code JwtEncryptionBuilder}.
      * 'A256GCM' content encryption algorithms will be used unless a different one have been set with

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/JwtSignature.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/JwtSignature.java
@@ -11,9 +11,11 @@ public interface JwtSignature {
 
     /**
      * Sign the claims with {@link PrivateKey}.
-     * 'RS256' algorithm will be used unless a different one has been set with {@code JwtSignatureBuilder}.
+     *
+     * 'RS256' algorithm will be used unless a different algorithm has been set with {@code JwtSignatureBuilder}.
+     *
      * A key of size 2048 bits or larger MUST be used with the 'RS256' algorithm.
-     * 
+     *
      * @param signingKey the signing key
      * @return signed JWT token
      * @throws JwtSignatureException the exception if the signing operation has failed
@@ -22,8 +24,8 @@ public interface JwtSignature {
 
     /**
      * Sign the claims with {@link SecretKey}
-     * 'RS256' algorithm will be used unless a different one has been set with {@code JwtSignatureBuilder}.
-     * A key of size 2048 bits or larger MUST be used with the 'RS256' algorithm.
+     *
+     * 'HS256' algorithm will be used unless a different algorithm has been set with {@code JwtSignatureBuilder}.
      *
      * @param signingKey the signing key
      * @return signed JWT token
@@ -34,9 +36,10 @@ public interface JwtSignature {
     /**
      * Sign the claims with a private or secret key loaded from the custom location
      * which can point to a PEM, JWK or JWK set keys.
-     * 'RS256' algorithm will be used unless a different one has been set with {@code JwtSignatureBuilder}.
+     *
+     * 'RS256' algorithm will be used unless a different algorithm has been set with {@code JwtSignatureBuilder}.
      * A key of size 2048 bits or larger MUST be used with the 'RS256' algorithm.
-     * 
+     *
      * @param keyLocation the signing key location
      * @return signed JWT token
      * @throws JwtSignatureException the exception if the signing operation has failed
@@ -44,9 +47,11 @@ public interface JwtSignature {
     String sign(String keyLocation) throws JwtSignatureException;
 
     /**
-     * Sign the claims with a key loaded from the location set with the "smallrye.jwt.sign.key-location" property
-     * which can point to a PEM, JWK or JWK set keys.
-     * 'RS256' algorithm will be used unless a different one has been set with {@code JwtSignatureBuilder}.
+     * Sign the claims with a key loaded from the location set with the "smallrye.jwt.sign.key.location"
+     * or "smallrye.jwt.sign.key-location" properties which can point to PEM, JWK or JWK set keys.
+     * Note: "smallrye.jwt.sign.key-location" property is deprecated and will be removed in the next major release.
+     *
+     * 'RS256' algorithm will be used unless a different algorithm has been set with {@code JwtSignatureBuilder}.
      * A key of size 2048 bits or larger MUST be used with the 'RS256' algorithm.
      *
      * @return signed JWT token
@@ -56,7 +61,8 @@ public interface JwtSignature {
 
     /**
      * Sign the claims with a secret key string.
-     * 'HS256' algorithm will be used unless a different one has been set with {@code JwtSignatureBuilder}.
+     *
+     * 'HS256' algorithm will be used unless a different algorithm has been set with {@code JwtSignatureBuilder}.
      *
      * @param secret the secret
      * @return signed JWT token
@@ -66,7 +72,8 @@ public interface JwtSignature {
 
     /**
      * Sign the claims with {@link PrivateKey} and encrypt the inner JWT by moving to {@link JwtEncryptionBuilder}.
-     * 'RS256' algorithm will be used unless a different one has been set with {@code JwtSignatureBuilder}.
+     * 'RS256' algorithm will be used unless a different algorithm has been set with {@code JwtSignatureBuilder}.
+     *
      * A key of size 2048 bits or larger MUST be used with the 'RS256' algorithm.
      *
      * @param signingKey the signing key
@@ -77,8 +84,8 @@ public interface JwtSignature {
 
     /**
      * Sign the claims with {@link SecretKey} and encrypt the inner JWT by moving to {@link JwtEncryptionBuilder}.
-     * 'RS256' algorithm will be used unless a different one has been set with {@code JwtSignatureBuilder}.
-     * A key of size 2048 bits or larger MUST be used with the 'RS256' algorithm.
+     *
+     * 'HS256' algorithm will be used unless a different algorithm has been set with {@code JwtSignatureBuilder}.
      *
      * @param signingKey the signing key
      * @return JwtEncryption
@@ -89,6 +96,7 @@ public interface JwtSignature {
     /**
      * Sign the claims with a private or secret key loaded from the custom location
      * which can point to a PEM, JWK or JWK set keys and encrypt the inner JWT by moving to {@link JwtEncryptionBuilder}.
+     *
      * 'RS256' algorithm will be used unless a different one has been set with {@code JwtSignatureBuilder}.
      * A key of size 2048 bits or larger MUST be used with the 'RS256' algorithm.
      *
@@ -99,13 +107,16 @@ public interface JwtSignature {
     JwtEncryptionBuilder innerSign(String keyLocation) throws JwtSignatureException;
 
     /**
-     * Sign the claims with a key loaded from the location set with the "smallrye.jwt.sign.key-location" property
-     * and encrypt the inner JWT by moving to {@link JwtEncryptionBuilder}.
+     * Sign the claims with a key loaded from the location set with the "smallrye.jwt.sign.key.location"
+     * or "smallrye.jwt.sign.key-location" properties and encrypt the inner JWT by moving to {@link JwtEncryptionBuilder}.
+     * Note: "smallrye.jwt.sign.key-location" property is deprecated and will be removed in the next major release.
      *
-     * If no "smallrye.jwt.sign.key-location" property and 'alg' algorithm header have been set then an insecure
-     * inner JWT with a "none" algorithm has to be created before being encrypted.
+     * If no "smallrye.jwt.sign.key.location" or "smallrye.jwt.sign.key-location" properties and 'alg' algorithm header
+     * have been set then an insecure inner JWT with a "none" algorithm has to be created before being encrypted.
+     * Note: support for the "none" algorithm has been deprecated and will be removed in the next major release.
+     *
      * A key of size 2048 bits or larger MUST be used with the 'RS256' algorithm.
-     * 
+     *
      * @return JwtEncryption
      * @throws JwtSignatureException the exception if the inner JWT signing operation has failed
      */

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/ImplLogging.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/ImplLogging.java
@@ -1,0 +1,20 @@
+package io.smallrye.jwt.build.impl;
+
+import org.jboss.logging.BasicLogger;
+import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.LogMessage;
+import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageLogger;
+
+@MessageLogger(projectCode = "SRJWT", length = 5)
+interface ImplLogging extends BasicLogger {
+    ImplLogging log = Logger.getMessageLogger(ImplLogging.class, ImplLogging.class.getPackage().getName());
+
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 1000, value = "%s property is deprecated and will be removed in the next major release")
+    void deprecatedProperty(String property);
+
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 1001, value = "Inner-sign none signature mode is deprecated and will be removed in the next major release")
+    void deprecatedInnerSignNone();
+}

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/ImplMessages.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/ImplMessages.java
@@ -94,6 +94,6 @@ interface ImplMessages {
     JwtException failureToReadJsonContentFromJsonResName(String jsonResName, String exceptionMessage,
             @Cause Throwable throwable);
 
-    @Message(id = 5027, value = "")
+    @Message(id = 5027, value = "Failure to encrypt the token")
     JwtEncryptionException encryptionException(@Cause Throwable throwable);
 }

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtEncryptionImpl.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtEncryptionImpl.java
@@ -21,6 +21,9 @@ import io.smallrye.jwt.util.KeyUtils;
  * Default JWT Encryption implementation
  */
 class JwtEncryptionImpl implements JwtEncryptionBuilder {
+    private static final String KEY_LOCATION_PROPERTY = "smallrye.jwt.encrypt.key.location";
+    private static final String DEPRECATED_KEY_LOCATION_PROPERTY = "smallrye.jwt.encrypt.key-location";
+
     boolean innerSigned;
     String claims;
     Map<String, Object> headers = new HashMap<>();
@@ -178,11 +181,16 @@ class JwtEncryptionImpl implements JwtEncryptionBuilder {
     }
 
     private static String getKeyLocationFromConfig() {
-        String keyLocation = JwtBuildUtils.getConfigProperty("smallrye.jwt.encrypt.key-location", String.class);
-        if (keyLocation == null) {
-            throw ImplMessages.msg.encryptionKeyLocationNotConfigured();
+        String keyLocation = JwtBuildUtils.getConfigProperty(KEY_LOCATION_PROPERTY, String.class);
+        if (keyLocation != null) {
+            return keyLocation;
         }
-        return keyLocation;
+        keyLocation = JwtBuildUtils.getConfigProperty(DEPRECATED_KEY_LOCATION_PROPERTY, String.class);
+        if (keyLocation != null) {
+            ImplLogging.log.deprecatedProperty(DEPRECATED_KEY_LOCATION_PROPERTY);
+            return keyLocation;
+        }
+        throw ImplMessages.msg.encryptionKeyLocationNotConfigured();
     }
 
     Key getEncryptionKeyFromKeyLocation(String keyLocation) {

--- a/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtBuildConfigSource.java
+++ b/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtBuildConfigSource.java
@@ -6,6 +6,10 @@ import java.util.Map;
 import org.eclipse.microprofile.config.spi.ConfigSource;
 
 public class JwtBuildConfigSource implements ConfigSource {
+    private static final String SIGN_KEY_LOCATION_PROPERTY = "smallrye.jwt.sign.key.location";
+    private static final String DEPRECATED_SIGN_KEY_LOCATION_PROPERTY = "smallrye.jwt.sign.key-location";
+    private static final String ENC_KEY_LOCATION_PROPERTY = "smallrye.jwt.encrypt.key.location";
+    private static final String DEPRECATED_ENC_KEY_LOCATION_PROPERTY = "smallrye.jwt.encrypt.key-location";
 
     boolean signingKeyAvailable = true;
     boolean lifespanPropertyRequired;
@@ -13,14 +17,16 @@ public class JwtBuildConfigSource implements ConfigSource {
     boolean audiencePropertyRequired;
     String encryptionKeyLocation = "/publicKey.pem";
     String signingKeyLocation = "/privateKey.pem";
+    String signingKeyLocProperty = SIGN_KEY_LOCATION_PROPERTY;
+    String encryptionKeyLocProperty = ENC_KEY_LOCATION_PROPERTY;
 
     @Override
     public Map<String, String> getProperties() {
         Map<String, String> map = new HashMap<>();
         if (signingKeyAvailable) {
-            map.put("smallrye.jwt.sign.key-location", signingKeyLocation);
+            map.put(signingKeyLocProperty, signingKeyLocation);
         }
-        map.put("smallrye.jwt.encrypt.key-location", encryptionKeyLocation);
+        map.put(encryptionKeyLocProperty, encryptionKeyLocation);
         if (lifespanPropertyRequired) {
             map.put("smallrye.jwt.new-token.lifespan", "2000");
         }
@@ -53,6 +59,14 @@ public class JwtBuildConfigSource implements ConfigSource {
 
     public void setSigningKeyLocation(String location) {
         this.signingKeyLocation = location;
+    }
+
+    public void enableDeprecatedSigningKeyProperty(boolean enable) {
+        this.signingKeyLocProperty = enable ? DEPRECATED_SIGN_KEY_LOCATION_PROPERTY : SIGN_KEY_LOCATION_PROPERTY;
+    }
+
+    public void enableDeprecatedEncryptionKeyProperty(boolean enable) {
+        this.encryptionKeyLocProperty = enable ? DEPRECATED_ENC_KEY_LOCATION_PROPERTY : ENC_KEY_LOCATION_PROPERTY;
     }
 
     void setLifespanPropertyRequired(boolean lifespanPropertyRequired) {

--- a/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtEncryptTest.java
+++ b/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtEncryptTest.java
@@ -183,6 +183,7 @@ public class JwtEncryptTest {
     public void testEncryptWithConfiguredEcKeyAndA128CBCHS256() throws Exception {
         JwtBuildConfigSource configSource = JwtSignTest.getConfigSource();
         configSource.setEncryptionKeyLocation("/ecPublicKey.pem");
+        configSource.enableDeprecatedEncryptionKeyProperty(true);
         String jweCompact = null;
         try {
             jweCompact = Jwt.claims()
@@ -194,6 +195,7 @@ public class JwtEncryptTest {
                     .encrypt();
         } finally {
             configSource.setEncryptionKeyLocation("/publicKey.pem");
+            configSource.enableDeprecatedEncryptionKeyProperty(false);
         }
 
         checkJweHeaders(jweCompact, "ECDH-ES+A256KW", "A128CBC-HS256", 4);

--- a/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtSignTest.java
+++ b/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtSignTest.java
@@ -530,6 +530,7 @@ public class JwtSignTest {
     public void testSignClaimsEcKey() throws Exception {
         JwtBuildConfigSource configSource = getConfigSource();
         configSource.setSigningKeyLocation("/ecPrivateKey.pem");
+        configSource.enableDeprecatedSigningKeyProperty(true);
         String jwt = null;
         try {
             jwt = Jwt.claims()
@@ -540,6 +541,7 @@ public class JwtSignTest {
                     .sign();
         } finally {
             configSource.setSigningKeyLocation("/privateKey.pem");
+            configSource.enableDeprecatedSigningKeyProperty(false);
         }
 
         PublicKey ecKey = getEcPublicKey();


### PR DESCRIPTION
Fixes #395 
Fixes #404 

this PR aligns the sign/encrypt key properties with the convention used for configuring the verification/decryption keys, deprecates an inner-sign none signature mode which can only add to the confusion, and cleans up some docs