### PR TITLE
Remove deprecated JWT Build API inner-sign none signature support and key location properties

### DIFF
--- a/doc/modules/ROOT/pages/generate-jwt.adoc
+++ b/doc/modules/ROOT/pages/generate-jwt.adoc
@@ -141,9 +141,7 @@ Smallrye JWT supports the following properties which can be used to customize th
 |===
 |Property Name|Default|Description
 |smallrye.jwt.encrypt.key.location|none|Location of a key which will be used to encrypt the claims or inner JWT when a no-argument encrypt() method is called.
-|smallrye.jwt.encrypt.key-location|none|Location of a key which will be used to encrypt the claims or inner JWT when a no-argument encrypt() method is called. This property is deprecated and will be removed in the next major release.
 |smallrye.jwt.sign.key.location|none|Location of a key which will be used to sign the claims when either a no-argument sign() or innerSign() method is called.
-|smallrye.jwt.sign.key-location|none|Location of a key which will be used to sign the claims when either a no-argument sign() or innerSign() method is called. This property is deprecated and will be removed in the next major release.
 |smallrye.jwt.new-token.lifespan|300|Token lifespan in seconds which will be used to calculate an `exp` (expiry) claim value if this claim has not already been set.
 |smallrye.jwt.new-token.issuer|none|Token issuer which can be used to set an `iss` (issuer) claim value if this claim has not already been set.
 |smallrye.jwt.new-token.audience|none|Token audience which can be used to set an `aud` (audience) claim value if this claim has not already been set.

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/JwtSignature.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/JwtSignature.java
@@ -111,10 +111,6 @@ public interface JwtSignature {
      * or "smallrye.jwt.sign.key-location" properties and encrypt the inner JWT by moving to {@link JwtEncryptionBuilder}.
      * Note: "smallrye.jwt.sign.key-location" property is deprecated and will be removed in the next major release.
      *
-     * If no "smallrye.jwt.sign.key.location" or "smallrye.jwt.sign.key-location" properties and 'alg' algorithm header
-     * have been set then an insecure inner JWT with a "none" algorithm has to be created before being encrypted.
-     * Note: support for the "none" algorithm has been deprecated and will be removed in the next major release.
-     *
      * A key of size 2048 bits or larger MUST be used with the 'RS256' algorithm.
      *
      * @return JwtEncryption


### PR DESCRIPTION
This is the very last PR into the `mpjwt12` branch. It affects `implementation/jwt-build` module only.
Support for the deprecated `none` innger-sign algorithm is dropped, and the deprecated  sign/encrypt `key-location` properties. are also dropped.