### PR TITLE
Use correct resource location for service loader logging of JWTCallerPrincipalFactory

### DIFF
--- a/implementation/jwt-auth/src/main/java/io/smallrye/jwt/auth/principal/JWTCallerPrincipalFactory.java
+++ b/implementation/jwt-auth/src/main/java/io/smallrye/jwt/auth/principal/JWTCallerPrincipalFactory.java
@@ -73,7 +73,7 @@ public abstract class JWTCallerPrincipalFactory {
 
         if (instance == null) {
             ServiceLoader<JWTCallerPrincipalFactory> sl = ServiceLoader.load(JWTCallerPrincipalFactory.class, cl);
-            URL u = cl.getResource("/META-INF/services/org.eclipse.microprofile.jwt.principal.JWTCallerPrincipalFactory");
+            URL u = cl.getResource("/META-INF/services/io.smallrye.jwt.auth.principal.JWTCallerPrincipalFactory");
             PrincipalLogging.log.loadSpi(cl, u, sl);
             try {
                 for (JWTCallerPrincipalFactory spi : sl) {


### PR DESCRIPTION
When loading an instance of JWTCallerPrincipalFactory via the `ServiceLoader`, that instance will need to be registered under the `io.smallrye.jwt.auth.principal.JWTCallerPrincipalFactory` entry in `./META-INF/services/`.

The logging component for this, however, makes use of an incorrect path for that resource. (There is no such `org.eclipse.microprofile.jwt.principal.JWTCallerPrincipalFactory` class or interface.)