### PR TITLE
Complete the removal of smallrye.jwt.sign.key-location and smallrye.jwt.encrypt.key-location properties

### DIFF
--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtEncryptionImpl.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtEncryptionImpl.java
@@ -22,7 +22,6 @@ import io.smallrye.jwt.util.KeyUtils;
  */
 class JwtEncryptionImpl implements JwtEncryptionBuilder {
     private static final String KEY_LOCATION_PROPERTY = "smallrye.jwt.encrypt.key.location";
-    private static final String DEPRECATED_KEY_LOCATION_PROPERTY = "smallrye.jwt.encrypt.key-location";
 
     boolean innerSigned;
     String claims;
@@ -183,11 +182,6 @@ class JwtEncryptionImpl implements JwtEncryptionBuilder {
     private static String getKeyLocationFromConfig() {
         String keyLocation = JwtBuildUtils.getConfigProperty(KEY_LOCATION_PROPERTY, String.class);
         if (keyLocation != null) {
-            return keyLocation;
-        }
-        keyLocation = JwtBuildUtils.getConfigProperty(DEPRECATED_KEY_LOCATION_PROPERTY, String.class);
-        if (keyLocation != null) {
-            ImplLogging.log.deprecatedProperty(DEPRECATED_KEY_LOCATION_PROPERTY);
             return keyLocation;
         }
         throw ImplMessages.msg.encryptionKeyLocationNotConfigured();

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtSignatureImpl.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtSignatureImpl.java
@@ -24,7 +24,6 @@ import io.smallrye.jwt.util.KeyUtils;
  */
 class JwtSignatureImpl implements JwtSignature {
     private static final String KEY_LOCATION_PROPERTY = "smallrye.jwt.sign.key.location";
-    private static final String DEPRECATED_KEY_LOCATION_PROPERTY = "smallrye.jwt.sign.key-location";
 
     JwtClaims claims = new JwtClaims();
     Map<String, Object> headers = new HashMap<>();
@@ -177,11 +176,6 @@ class JwtSignatureImpl implements JwtSignature {
     static String getKeyLocationFromConfig() {
         String keyLocation = JwtBuildUtils.getConfigProperty(KEY_LOCATION_PROPERTY, String.class);
         if (keyLocation != null) {
-            return keyLocation;
-        }
-        keyLocation = JwtBuildUtils.getConfigProperty(DEPRECATED_KEY_LOCATION_PROPERTY, String.class);
-        if (keyLocation != null) {
-            ImplLogging.log.deprecatedProperty(DEPRECATED_KEY_LOCATION_PROPERTY);
             return keyLocation;
         }
         throw ImplMessages.msg.signKeyLocationNotConfigured();

--- a/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtBuildConfigSource.java
+++ b/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtBuildConfigSource.java
@@ -10,9 +10,7 @@ import org.eclipse.microprofile.config.spi.ConfigSource;
 
 public class JwtBuildConfigSource implements ConfigSource {
     private static final String SIGN_KEY_LOCATION_PROPERTY = "smallrye.jwt.sign.key.location";
-    private static final String DEPRECATED_SIGN_KEY_LOCATION_PROPERTY = "smallrye.jwt.sign.key-location";
     private static final String ENC_KEY_LOCATION_PROPERTY = "smallrye.jwt.encrypt.key.location";
-    private static final String DEPRECATED_ENC_KEY_LOCATION_PROPERTY = "smallrye.jwt.encrypt.key-location";
 
     boolean signingKeyAvailable = true;
     boolean lifespanPropertyRequired;
@@ -62,14 +60,6 @@ public class JwtBuildConfigSource implements ConfigSource {
 
     public void setSigningKeyLocation(String location) {
         this.signingKeyLocation = location;
-    }
-
-    public void enableDeprecatedSigningKeyProperty(boolean enable) {
-        this.signingKeyLocProperty = enable ? DEPRECATED_SIGN_KEY_LOCATION_PROPERTY : SIGN_KEY_LOCATION_PROPERTY;
-    }
-
-    public void enableDeprecatedEncryptionKeyProperty(boolean enable) {
-        this.encryptionKeyLocProperty = enable ? DEPRECATED_ENC_KEY_LOCATION_PROPERTY : ENC_KEY_LOCATION_PROPERTY;
     }
 
     void setLifespanPropertyRequired(boolean lifespanPropertyRequired) {

--- a/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtEncryptTest.java
+++ b/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtEncryptTest.java
@@ -183,7 +183,6 @@ public class JwtEncryptTest {
     public void testEncryptWithConfiguredEcKeyAndA128CBCHS256() throws Exception {
         JwtBuildConfigSource configSource = JwtSignTest.getConfigSource();
         configSource.setEncryptionKeyLocation("/ecPublicKey.pem");
-        configSource.enableDeprecatedEncryptionKeyProperty(true);
         String jweCompact = null;
         try {
             jweCompact = Jwt.claims()
@@ -195,7 +194,6 @@ public class JwtEncryptTest {
                     .encrypt();
         } finally {
             configSource.setEncryptionKeyLocation("/publicKey.pem");
-            configSource.enableDeprecatedEncryptionKeyProperty(false);
         }
 
         checkJweHeaders(jweCompact, "ECDH-ES+A256KW", "A128CBC-HS256", 4);

--- a/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtSignTest.java
+++ b/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtSignTest.java
@@ -530,7 +530,6 @@ public class JwtSignTest {
     public void testSignClaimsEcKey() throws Exception {
         JwtBuildConfigSource configSource = getConfigSource();
         configSource.setSigningKeyLocation("/ecPrivateKey.pem");
-        configSource.enableDeprecatedSigningKeyProperty(true);
         String jwt = null;
         try {
             jwt = Jwt.claims()
@@ -541,7 +540,6 @@ public class JwtSignTest {
                     .sign();
         } finally {
             configSource.setSigningKeyLocation("/privateKey.pem");
-            configSource.enableDeprecatedSigningKeyProperty(false);
         }
 
         PublicKey ecKey = getEcPublicKey();


### PR DESCRIPTION
@radcortez @darranl @MikeEdgar 

This PR follows #413 and actually completes the removal of these 2 deprecated properties in 3.0.0. I've run Quarkus `microprofile-4` branch and I did not see the failing tests which rely on those deprecated properties so I realized the previous PR was not complete. Roberto, Darran, I've got your approval to the earlier PR so I'll go ahead with merging this one once it passes the builds - the updates are very simple - the drop the properties typed as `DEPRECATED_...` in the code :-) 