### PR TITLE
Issue#427 DefaultJWTTokenParser#parseClaims Exception Handling

### DIFF
--- a/implementation/jwt-auth/src/main/java/io/smallrye/jwt/auth/principal/DefaultJWTTokenParser.java
+++ b/implementation/jwt-auth/src/main/java/io/smallrye/jwt/auth/principal/DefaultJWTTokenParser.java
@@ -152,8 +152,13 @@ public class DefaultJWTTokenParser {
 
             return jwtContext;
         } catch (InvalidJwtException e) {
-            PrincipalLogging.log.tokenInvalid();
-            throw PrincipalMessages.msg.failedToVerifyToken(e);
+            if (e.getCause() instanceof UnresolvableKeyException) {
+                PrincipalLogging.log.verificationKeyUnresolvable();
+                throw PrincipalMessages.msg.failedToVerifyToken(e.getCause());
+            } else {
+                PrincipalLogging.log.tokenInvalid();
+                throw PrincipalMessages.msg.failedToVerifyToken(e);
+            }
         } catch (UnresolvableKeyException e) {
             PrincipalLogging.log.verificationKeyUnresolvable();
             throw PrincipalMessages.msg.failedToVerifyToken(e);

--- a/testsuite/basic/src/test/java/io/smallrye/jwt/auth/principal/DefaultJWTParserTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/jwt/auth/principal/DefaultJWTParserTest.java
@@ -11,7 +11,7 @@ import javax.crypto.SecretKey;
 import org.eclipse.microprofile.jwt.JsonWebToken;
 import org.jose4j.jwk.JsonWebKey;
 import org.jose4j.jwk.PublicJsonWebKey;
-import org.jose4j.jwt.consumer.InvalidJwtException;
+import org.jose4j.lang.UnresolvableKeyException;
 import org.junit.Test;
 
 import io.smallrye.jwt.algorithm.KeyEncryptionAlgorithm;
@@ -75,9 +75,9 @@ public class DefaultJWTParserTest {
         JWTAuthContextInfo config = new JWTAuthContextInfo("/certificate.pem", "https://server.example.com");
         config.setVerifyCertificateThumbprint(true);
         JWTParser parser = new DefaultJWTParser(config);
-        ParseException thrown = assertThrows("InvalidJwtException is expected",
+        ParseException thrown = assertThrows("UnresolvableKeyException is expected",
                 ParseException.class, () -> parser.parse(jwtString));
-        assertTrue(thrown.getCause() instanceof InvalidJwtException);
+        assertTrue(thrown.getCause() instanceof UnresolvableKeyException);
     }
 
     @Test

--- a/testsuite/basic/src/test/java/io/smallrye/jwt/auth/principal/KeyLocationResolverTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/jwt/auth/principal/KeyLocationResolverTest.java
@@ -46,7 +46,7 @@ public class KeyLocationResolverTest {
             verifyToken("key2", null, "publicKey.jwk");
             Assert.fail("ParseException is expected");
         } catch (ParseException ex) {
-            Assert.assertTrue(ex.getCause().getCause() instanceof UnresolvableKeyException);
+            Assert.assertTrue(ex.getCause() instanceof UnresolvableKeyException);
         }
     }
 
@@ -71,7 +71,7 @@ public class KeyLocationResolverTest {
             verifyToken("key2", "key1", "publicKeySet.jwk");
             Assert.fail("ParseException is expected");
         } catch (ParseException ex) {
-            Assert.assertTrue(ex.getCause().getCause() instanceof UnresolvableKeyException);
+            Assert.assertTrue(ex.getCause() instanceof UnresolvableKeyException);
         }
     }
 
@@ -81,7 +81,7 @@ public class KeyLocationResolverTest {
             verifyToken("key3", null, "publicKeySet.jwk");
             Assert.fail("ParseException is expected");
         } catch (ParseException ex) {
-            Assert.assertTrue(ex.getCause().getCause() instanceof UnresolvableKeyException);
+            Assert.assertTrue(ex.getCause() instanceof UnresolvableKeyException);
         }
     }
 
@@ -156,7 +156,7 @@ public class KeyLocationResolverTest {
             new DefaultJWTTokenParser().parse(jwt, contextInfo);
             Assert.fail("ParseException is expected due to the wrong key type");
         } catch (ParseException ex) {
-            Assert.assertTrue(ex.getCause().getCause() instanceof UnresolvableKeyException);
+            Assert.assertTrue(ex.getCause() instanceof UnresolvableKeyException);
         }
     }
 


### PR DESCRIPTION
Fixes #427 

When a invalid public key has been configured in the `mp.jwt.verify.publickey.location`, an `UnresolvableKeyException` should be reported. However, if this exception arises inside the call to the JOSE method, then the `UnresolvableKeyException` gets wrapped in a `InvalidJwtException` by the JOSE method, resulting in the wrong error code being sent in `JWTHTTPAuthenticationMechanism.`