### PR TITLE
Remove a long time deprecated JwtClaimsBuilder.json() method

### DIFF
--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/JwtClaimsBuilder.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/JwtClaimsBuilder.java
@@ -199,19 +199,6 @@ public interface JwtClaimsBuilder extends JwtSignature {
     JwtClaimsBuilder claim(String name, Object value);
 
     /**
-     * Return a JSON representation of the claims before they have been signed or encrypted.
-     * Note that the 'iat' (issued at time), 'exp' (expiration time) and 'jti' (unique token identifier) claims
-     * must be set if they have not already been set before creating a JSON representation to ensure it is consistent
-     * with what will be signed or encrypted.
-     * This method will return the same JSON representation if called multiple times unless some new claims have
-     * been added since the previous call.
-     *
-     * @return the JSON representation
-     */
-    @Deprecated
-    String json();
-
-    /**
      * Set JsonWebSignature headers and sign the claims by moving to {@link JwtSignatureBuilder}
      * 
      * @return JwtSignatureBuilder

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtClaimsBuilderImpl.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtClaimsBuilderImpl.java
@@ -264,15 +264,6 @@ class JwtClaimsBuilderImpl extends JwtSignatureImpl implements JwtClaimsBuilder,
      * {@inheritDoc}
      */
     @Override
-    public String json() {
-        JwtBuildUtils.setDefaultJwtClaims(claims, tokenLifespan);
-        return claims.toJson();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public JwtEncryptionBuilder jwe() {
         JwtBuildUtils.setDefaultJwtClaims(claims, tokenLifespan);
         return new JwtEncryptionImpl(claims.toJson());

--- a/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtSignTest.java
+++ b/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtSignTest.java
@@ -103,7 +103,6 @@ public class JwtSignTest {
         return signAndVerifyClaims(null, null, null);
     }
 
-    @SuppressWarnings("deprecation")
     private JwtClaims signAndVerifyClaims(Long customLifespan, String issuer, String aud) throws Exception {
         JwtClaimsBuilder builder = Jwt.claims().claim("customClaim", "custom-value");
         if (issuer == null) {
@@ -112,12 +111,8 @@ public class JwtSignTest {
         if (aud == null) {
             builder.audience("https://localhost:8081");
         }
-        String jsonBeforeSign = builder.json();
         String jwt = builder.sign(getPrivateKey());
-        String jsonAfterSign = builder.json();
-        Assert.assertEquals(jsonBeforeSign, jsonAfterSign);
         JsonWebSignature jws = getVerifiedJws(jwt);
-        Assert.assertEquals(jsonAfterSign, jws.getPayload());
         JwtClaims claims = JwtClaims.parse(jws.getPayload());
         Assert.assertEquals(6, claims.getClaimsMap().size());
         checkDefaultClaimsAndHeaders(getJwsHeaders(jwt, 2), claims, "RS256", customLifespan != null ? customLifespan : 300);


### PR DESCRIPTION
I thought I did remove all the deprecated methods/classes but with all the 3.0.0 pre-release activity, this long time deprecated method has been left around.
It was deprecated for at least 4 months, and its specification is weak and difficult to implement correctly, and the point of this method is also hard to justify. So I'd like to avoid smallrye-jwt carrying it around for another year or so :-) before we have 4.0.0 :-).
I honestly don't expect anyone be affected by it, i.e don't think the users have started using a deprecated `.json()` method during the last few weeks in 3.0.0

CC @darranl Darran, 100% not related to MP JWT 1.2 