### PR TITLE
Update README to refer to MP JWT 1.2 and remove the references to RSA-OAEP-256 being the default key enc algorithm

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -10,9 +10,7 @@ image:https://img.shields.io/maven-central/v/io.smallrye/smallrye-jwt?color=gree
 
 = SmallRye JWT
 
-SmallRye JWT is a library for implementing the {microprofile-jwt}[{mp-jwt-name}]. Currently it is focused on supporting the MP-JWT 1.1 spec, and primarily deals with the parsing of the JWT string into a JsonWebToken implementation.
-
-In the future, when MP-JWT 2.0 can build on the JSR-375 security APIs, there should be more support for defining the CDI extension and security layer integration.
+SmallRye JWT is a library for implementing the {microprofile-jwt}[{mp-jwt-name}]. Currently it is focused on supporting the MP-JWT 1.2 spec. It deals with the decryption and/or signature verification of the JWT token and parsing it into a JsonWebToken implementation.
 
 == Instructions
 
@@ -25,7 +23,13 @@ mvn clean install
 
 === Project structure
 
-* link:implementation[] - Implementation of the {mp-jwt-name} library.
+* link:implementation[] - Implementation of the {mp-jwt-name} library
+** link:implementation/common[] - Common utility classes.
+** link:implementation/jwt-auth[] - Core library implementation.
+** link:implementation/jwt-cdi[] - Support for registering the implementation as CDI extension.
+** link:implementation/jwt-http-mechanism[] - Support for registering the implementation as HTTP Authentication Mechanism.
+** link:implementation/jwt-jaxrs[] - Support for registering the implementation as JAX-RS feature and filters.
+** link:implementation/jwt-build[] - Support for generating JWT tokens - this module is not related to MP JWT 1.2.
 * link:testsuite[] - Test suites
 ** link:testsuite/basic[] Test suite with basic test cases.
 ** link:testsuite/tck[] Test suite to run the implementation against the {mp-jwt-name} TCK.

--- a/doc/modules/ROOT/pages/generate-jwt.adoc
+++ b/doc/modules/ROOT/pages/generate-jwt.adoc
@@ -102,8 +102,7 @@ String jwt1 = Jwt.claims("/tokenClaims.json").jwe().encrypt();
 String jwt2 = Jwt.claims("/tokenClaims.json").jwe().header("custom-header", "custom-value").encrypt(getPublicKey());
 ----
 
-Note the `alg` (key management algorithm) header is set to `RSA-OAEP-256` (it will be changed to `RSA-OAEP` in a future
-version of smallrye-jwt) and the `enc` (content encryption header) is set to `A256GCM` by default.
+Note the `alg` (key management algorithm) header is set to `RSA-OAEP` and the `enc` (content encryption header) is set to `A256GCM` by default.
 
 == Sign the claims and encrypt the nested JWT token
 

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/JwtEncryption.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/JwtEncryption.java
@@ -11,14 +11,11 @@ public interface JwtEncryption {
 
     /**
      * Encrypt the claims or inner JWT with {@link PublicKey}.
-     * 'RSA-OAEP-256' and 'ECDH-ES+A256KW' key encryption algorithms will be used by default
+     * 'RSA-OAEP' and 'ECDH-ES+A256KW' key encryption algorithms will be used by default
      * when public RSA or EC keys are used unless a different one has been set with {@code JwtEncryptionBuilder}.
      * 'A256GCM' content encryption algorithms will be used unless a different one have been set with
      * {@code JwtEncryptionBuilder}.
      * A key of size 2048 bits or larger MUST be used with the 'RSA-OAEP' and 'RSA-OAEP-256' algorithms.
-     *
-     * Note: Setting 'RSA-OAEP-256' as a default key encryption algorithm when public RSA keys are used is deprecated.
-     * Future version of this API will set 'RSA-OAEP' by default.
      *
      * @param keyEncryptionKey the key which encrypts the content encryption key
      * @return encrypted JWT token
@@ -40,14 +37,11 @@ public interface JwtEncryption {
     /**
      * Encrypt the claims or inner JWT with a public or secret key loaded from the custom location
      * which can point to a PEM, JWK or JWK set keys.
-     * 'RSA-OAEP-256', 'ECDH-ES+A256KW' and 'A256KW' key encryption algorithms will be used by default
+     * 'RSA-OAEP', 'ECDH-ES+A256KW' and 'A256KW' key encryption algorithms will be used by default
      * when public RSA, EC or secret keys are used unless a different one has been set with {@code JwtEncryptionBuilder}.
      * 'A256GCM' content encryption algorithms will be used unless a different one have been set with
      * {@code JwtEncryptionBuilder}.
      * A key of size 2048 bits or larger MUST be used with the 'RSA-OAEP' and 'RSA-OAEP-256' algorithms.
-     *
-     * Note: Setting 'RSA-OAEP-256' as a default key encryption algorithm when public RSA keys are used is deprecated.
-     * Future version of this API will set 'RSA-OAEP' by default.
      *
      * @param keyLocation the location of the keyEncryptionKey which encrypts the content encryption key
      * @return encrypted JWT token
@@ -61,14 +55,11 @@ public interface JwtEncryption {
      * 
      * Note: "smallrye.jwt.encrypt.key-location" property is deprecated and will be removed in the next major release.
      * 
-     * 'RSA-OAEP-256', 'ECDH-ES+A256KW' and 'A256KW' key encryption algorithms will be used by default
+     * 'RSA-OAEP', 'ECDH-ES+A256KW' and 'A256KW' key encryption algorithms will be used by default
      * when public RSA, EC or secret keys are used unless a different one has been set with {@code JwtEncryptionBuilder}.
      * 'A256GCM' content encryption algorithms will be used unless a different one have been set with
      * {@code JwtEncryptionBuilder}.
      * A key of size 2048 bits or larger MUST be used with the 'RSA-OAEP' and 'RSA-OAEP-256' algorithms.
-     *
-     * Note: Setting 'RSA-OAEP-256' as a default key encryption algorithm when public RSA keys are used is deprecated.
-     * Future version of this API will set 'RSA-OAEP' by default.
      *
      * @return encrypted JWT token
      * @throws JwtEncryptionException the exception if the encryption operation has failed


### PR DESCRIPTION
Fixes #443