### PR TITLE
Use JWK 'alg' and 'kid' when creating JWT if these headers are not set

### DIFF
--- a/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtEncryptJwkTest.java
+++ b/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtEncryptJwkTest.java
@@ -1,0 +1,77 @@
+/*
+ *   Copyright 2019 Red Hat, Inc, and individual contributors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package io.smallrye.jwt.build;
+
+import static org.junit.Assert.assertThrows;
+
+import java.security.Key;
+
+import org.jose4j.jwe.JsonWebEncryption;
+import org.jose4j.jwt.JwtClaims;
+import org.junit.Assert;
+import org.junit.Test;
+
+import io.smallrye.jwt.algorithm.KeyEncryptionAlgorithm;
+import io.smallrye.jwt.util.KeyUtils;
+
+public class JwtEncryptJwkTest {
+
+    @Test
+    public void testEncryptA256KW() throws Exception {
+        String jwt = Jwt.preferredUserName("alice").jwe().encrypt("/privateKey.jwk");
+        JsonWebEncryption jwe = getJsonWebEncryption(jwt, readSecretKey("/privateKey.jwk"));
+        Assert.assertEquals("secretkey1", jwe.getHeader("kid"));
+        // HS256 is a default value
+        Assert.assertEquals("A256KW", jwe.getHeader("alg"));
+        JwtClaims claims = JwtClaims.parse(jwe.getPayload());
+        Assert.assertEquals("alice", claims.getClaimValue("preferred_username"));
+
+    }
+
+    @Test
+    public void testEncryptA128KW() throws Exception {
+        String jwt = Jwt.preferredUserName("alice").jwe().encrypt("/privateKeyA128KW.jwk");
+        JsonWebEncryption jwe = getJsonWebEncryption(jwt,
+                readSecretKey("/privateKeyA128KW.jwk", KeyEncryptionAlgorithm.A128KW));
+        Assert.assertEquals("secretkey3", jwe.getHeader("kid"));
+        Assert.assertEquals("A128KW", jwe.getHeader("alg"));
+        JwtClaims claims = JwtClaims.parse(jwe.getPayload());
+        Assert.assertEquals("alice", claims.getClaimValue("preferred_username"));
+    }
+
+    @Test
+    public void testAlgorithmMismatch() throws Exception {
+        assertThrows("JwtEncryptionException is expected", JwtEncryptionException.class,
+                () -> Jwt.preferredUserName("alice").jwe().keyAlgorithm(KeyEncryptionAlgorithm.A256KW)
+                        .encrypt("/privateKeyA128KW.jwk"));
+    }
+
+    private Key readSecretKey(String keyLocation) throws Exception {
+        return readSecretKey(keyLocation, KeyEncryptionAlgorithm.A256KW);
+    }
+
+    private Key readSecretKey(String keyLocation, KeyEncryptionAlgorithm keyAlg) throws Exception {
+        return KeyUtils.readEncryptionKey(keyLocation, null, keyAlg);
+    }
+
+    private static JsonWebEncryption getJsonWebEncryption(String compactJwe, Key decryptionKey) throws Exception {
+        JsonWebEncryption jwe = new JsonWebEncryption();
+        jwe.setCompactSerialization(compactJwe);
+        jwe.setKey(decryptionKey);
+        return jwe;
+    }
+}

--- a/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtSignJwkTest.java
+++ b/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtSignJwkTest.java
@@ -1,0 +1,77 @@
+/*
+ *   Copyright 2019 Red Hat, Inc, and individual contributors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package io.smallrye.jwt.build;
+
+import static org.junit.Assert.assertThrows;
+
+import java.security.Key;
+
+import org.jose4j.jws.JsonWebSignature;
+import org.jose4j.jwt.JwtClaims;
+import org.junit.Assert;
+import org.junit.Test;
+
+import io.smallrye.jwt.algorithm.SignatureAlgorithm;
+import io.smallrye.jwt.util.KeyUtils;
+
+public class JwtSignJwkTest {
+
+    @Test
+    public void testSignHS256() throws Exception {
+        String jwt = Jwt.preferredUserName("alice").sign("/privateKey.jwk");
+        JsonWebSignature jws = getVerifiedJws(jwt, readSecretKey("/privateKey.jwk"));
+        Assert.assertEquals("secretkey1", jws.getHeader("kid"));
+        // HS256 is a default value
+        Assert.assertEquals("HS256", jws.getHeader("alg"));
+        JwtClaims claims = JwtClaims.parse(jws.getPayload());
+        Assert.assertEquals("alice", claims.getClaimValue("preferred_username"));
+
+    }
+
+    @Test
+    public void testSignHS512() throws Exception {
+        String jwt = Jwt.preferredUserName("alice").sign("/privateKeyHS512.jwk");
+        JsonWebSignature jws = getVerifiedJws(jwt, readSecretKey("/privateKeyHS512.jwk", SignatureAlgorithm.HS512));
+        Assert.assertEquals("secretkey2", jws.getHeader("kid"));
+        Assert.assertEquals("HS512", jws.getHeader("alg"));
+        JwtClaims claims = JwtClaims.parse(jws.getPayload());
+        Assert.assertEquals("alice", claims.getClaimValue("preferred_username"));
+    }
+
+    @Test
+    public void testAlgorithmMismatch() throws Exception {
+        assertThrows("JwtSignatureException is expected", JwtSignatureException.class,
+                () -> Jwt.preferredUserName("alice").jws().algorithm(SignatureAlgorithm.HS256)
+                        .sign("/privateKeyHS512.jwk"));
+    }
+
+    private Key readSecretKey(String keyLocation) throws Exception {
+        return readSecretKey(keyLocation, SignatureAlgorithm.HS256);
+    }
+
+    private Key readSecretKey(String keyLocation, SignatureAlgorithm sigAlg) throws Exception {
+        return KeyUtils.readSigningKey(keyLocation, null, sigAlg);
+    }
+
+    static JsonWebSignature getVerifiedJws(String jwt, Key key) throws Exception {
+        JsonWebSignature jws = new JsonWebSignature();
+        jws.setKey(key);
+        jws.setCompactSerialization(jwt);
+        Assert.assertTrue(jws.verifySignature());
+        return jws;
+    }
+}

--- a/implementation/jwt-build/src/test/resources/privateKeyA128KW.jwk
+++ b/implementation/jwt-build/src/test/resources/privateKeyA128KW.jwk
@@ -1,0 +1,6 @@
+{
+  "kty":"oct",
+  "k":"mHgOIP5oLngqXKq0123456",
+  "kid": "secretkey3",
+  "alg": "A128KW"
+}

--- a/implementation/jwt-build/src/test/resources/privateKeyHS512.jwk
+++ b/implementation/jwt-build/src/test/resources/privateKeyHS512.jwk
@@ -1,0 +1,6 @@
+{
+  "kty":"oct",
+  "k":"mHgOIP5oLngqXKq0jo4AkG_I0aY0nRIgAfuB8p-MW9zvxTpW9GPapkIdNcHxe5Y1lCnfVWSePazRaePg2uf9Sg",
+  "kid": "secretkey2",
+  "alg": "HS512"
+}


### PR DESCRIPTION
Fixes #321.

This PR makes sure that `alg` and `kid` properties do not have to be set manually when `JWK` keys are used to sign or encrypt the claims and those keys have already either `alg` and/or `kid` set. 

`KeyUtils` have been updated a bit - none of that code is used by the server side MP JWT code.
Also CC @SoniaZaldana 