### PR TITLE
Removing more references to 'smallrye.jwt.sign.key-location' and 'smallrye.jwt.encrypt.key-location'

### DIFF
--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/JwtEncryption.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/JwtEncryption.java
@@ -51,9 +51,7 @@ public interface JwtEncryption {
 
     /**
      * Encrypt the claims or inner JWT with a key loaded from the location set with the
-     * "smallrye.jwt.encrypt.key-location" or "smallrye.jwt.encrypt.key.location" properties.
-     * 
-     * Note: "smallrye.jwt.encrypt.key-location" property is deprecated and will be removed in the next major release.
+     * "smallrye.jwt.encrypt.key.location" property.
      * 
      * 'RSA-OAEP', 'ECDH-ES+A256KW' and 'A256KW' key encryption algorithms will be used by default
      * when public RSA, EC or secret keys are used unless a different one has been set with {@code JwtEncryptionBuilder}.

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/JwtSignature.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/JwtSignature.java
@@ -48,8 +48,7 @@ public interface JwtSignature {
 
     /**
      * Sign the claims with a key loaded from the location set with the "smallrye.jwt.sign.key.location"
-     * or "smallrye.jwt.sign.key-location" properties which can point to PEM, JWK or JWK set keys.
-     * Note: "smallrye.jwt.sign.key-location" property is deprecated and will be removed in the next major release.
+     * property which can point to PEM, JWK or JWK set keys.
      *
      * 'RS256' algorithm will be used unless a different algorithm has been set with {@code JwtSignatureBuilder}.
      * A key of size 2048 bits or larger MUST be used with the 'RS256' algorithm.
@@ -108,8 +107,7 @@ public interface JwtSignature {
 
     /**
      * Sign the claims with a key loaded from the location set with the "smallrye.jwt.sign.key.location"
-     * or "smallrye.jwt.sign.key-location" properties and encrypt the inner JWT by moving to {@link JwtEncryptionBuilder}.
-     * Note: "smallrye.jwt.sign.key-location" property is deprecated and will be removed in the next major release.
+     * property and encrypt the inner JWT by moving to {@link JwtEncryptionBuilder}.
      *
      * A key of size 2048 bits or larger MUST be used with the 'RS256' algorithm.
      *


### PR DESCRIPTION
this PR removes (hopefully) the last references to the properties which are no longer supported in JWT build API