### PR TITLE
Ensure JWT ID is unique when the claims or signature builder is reused

### DIFF
--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/JwtClaimsBuilder.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/JwtClaimsBuilder.java
@@ -17,6 +17,7 @@ import org.eclipse.microprofile.jwt.Claims;
  * <p>
  * JwtClaimsBuilder implementations must set the 'iat' (issued at time), 'exp' (expiration time)
  * and 'jti' (unique token identifier) claims unless they have already been set.
+ * JwtClaimsBuilder must ensure a 'jti' claim value is unique when the same builder is used for building more than one token.
  * <p>
  * By default the 'iat' claim is set to the current time in seconds and the 'exp' claim is set by adding a default token
  * lifespan value of 5 minutes to the 'iat' claim value. The 'smallrye.jwt.new-token.lifespan' property can be used to

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/JwtEncryptionBuilder.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/JwtEncryptionBuilder.java
@@ -12,7 +12,9 @@ import io.smallrye.jwt.algorithm.KeyEncryptionAlgorithm;
  * The 'cty' (content type) header must be set to 'JWT' when the inner signed JWT is encrypted.
  * <p>
  * Note that JwtEncryptionBuilder implementations are not expected to be thread-safe.
- * 
+ * However reusing a single JwtEncryptionBuilder for creating more than one encrypted token is not recommended
+ * because a single JwtEncryptionBuilder can not provide a unique token identifier per every token.
+ *
  * @see <a href="https://tools.ietf.org/html/rfc7516">RFC7516</a>
  */
 public interface JwtEncryptionBuilder extends JwtEncryption {

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtBuildUtils.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtBuildUtils.java
@@ -30,9 +30,11 @@ public class JwtBuildUtils {
             claims.setIssuedAt(NumericDate.fromSeconds(currentTimeInSecs()));
         }
         setExpiryClaim(claims, tokenLifespan);
+
         if (!claims.hasClaim(Claims.jti.name())) {
             claims.setClaim(Claims.jti.name(), UUID.randomUUID().toString());
         }
+
         Boolean overrideMatchingClaims = getConfigProperty(NEW_TOKEN_OVERRIDE_CLAIMS, Boolean.class);
         if (Boolean.TRUE.equals(overrideMatchingClaims) || !claims.hasClaim(Claims.iss.name())) {
             String issuer = getConfigProperty(NEW_TOKEN_ISSUER, String.class);

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtClaimsBuilderImpl.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtClaimsBuilderImpl.java
@@ -266,7 +266,11 @@ class JwtClaimsBuilderImpl extends JwtSignatureImpl implements JwtClaimsBuilder,
     @Override
     public JwtEncryptionBuilder jwe() {
         JwtBuildUtils.setDefaultJwtClaims(claims, tokenLifespan);
-        return new JwtEncryptionImpl(claims.toJson());
+        try {
+            return new JwtEncryptionImpl(claims.toJson());
+        } finally {
+            removeJti();
+        }
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtSignatureImpl.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtSignatureImpl.java
@@ -9,6 +9,7 @@ import java.util.Map;
 
 import javax.crypto.SecretKey;
 
+import org.eclipse.microprofile.jwt.Claims;
 import org.jose4j.jwa.AlgorithmConstraints;
 import org.jose4j.jwk.JsonWebKey;
 import org.jose4j.jws.JsonWebSignature;
@@ -75,6 +76,8 @@ class JwtSignatureImpl implements JwtSignature {
             throw ex;
         } catch (Exception ex) {
             throw ImplMessages.msg.signatureException(ex);
+        } finally {
+            removeJti();
         }
     }
 
@@ -115,8 +118,11 @@ class JwtSignatureImpl implements JwtSignature {
      */
     @Override
     public JwtEncryptionBuilder innerSign() throws JwtSignatureException {
-
-        return new JwtEncryptionImpl(sign(), true);
+        try {
+            return new JwtEncryptionImpl(sign(), true);
+        } finally {
+            removeJti();
+        }
     }
 
     @Override
@@ -218,5 +224,9 @@ class JwtSignatureImpl implements JwtSignature {
             throw ImplMessages.msg.signingKeyCanNotBeLoadedFromLocation(keyLocation);
         }
 
+    }
+
+    void removeJti() {
+        claims.unsetClaim(Claims.jti.name());
     }
 }

--- a/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtSignEncryptTest.java
+++ b/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtSignEncryptTest.java
@@ -45,19 +45,20 @@ public class JwtSignEncryptTest {
 
     @Test
     public void testSimpleInnerSignAndEncryptWithPemRsaPublicKey() throws Exception {
-        String jweCompact = Jwt.claims()
-                .claim("customClaim", "custom-value")
-                .innerSign()
-                .encrypt();
+        JwtClaimsBuilder builder = Jwt.claims().claim("customClaim", "custom-value");
+        String jti1 = checkRsaInnerSignedEncryptedClaims(builder.innerSign().encrypt());
+        Assert.assertNotNull(jti1);
+        String jti2 = checkRsaInnerSignedEncryptedClaims(builder.innerSign().encrypt());
+        Assert.assertNotNull(jti2);
 
-        checkRsaInnerSignedEncryptedClaims(jweCompact);
+        Assert.assertNotEquals(jti1, jti2);
     }
 
-    private void checkRsaInnerSignedEncryptedClaims(String jweCompact) throws Exception {
-        checkRsaInnerSignedEncryptedClaims(jweCompact, "RSA-OAEP-256");
+    private String checkRsaInnerSignedEncryptedClaims(String jweCompact) throws Exception {
+        return checkRsaInnerSignedEncryptedClaims(jweCompact, "RSA-OAEP-256");
     }
 
-    private void checkRsaInnerSignedEncryptedClaims(String jweCompact, String keyEncAlgo) throws Exception {
+    private String checkRsaInnerSignedEncryptedClaims(String jweCompact, String keyEncAlgo) throws Exception {
         checkJweHeaders(jweCompact, keyEncAlgo, null);
 
         JsonWebEncryption jwe = getJsonWebEncryption(jweCompact);
@@ -71,6 +72,7 @@ public class JwtSignEncryptTest {
         checkClaimsAndJwsHeaders(jwtCompact, claims, "RS256", null);
 
         Assert.assertEquals("custom-value", claims.getClaimValue("customClaim"));
+        return claims.getJwtId();
     }
 
     @Test

--- a/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtSignTest.java
+++ b/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtSignTest.java
@@ -295,9 +295,16 @@ public class JwtSignTest {
 
     @Test
     public void testSignClaimsConfiguredKey() throws Exception {
-        String jwt = Jwt.claims()
-                .claim("customClaim", "custom-value")
-                .sign();
+        JwtClaimsBuilder builder = Jwt.claims().claim("customClaim", "custom-value");
+        String jti1 = doTestSignClaimsConfiguredKey(builder);
+        Assert.assertNotNull(jti1);
+        String jti2 = doTestSignClaimsConfiguredKey(builder);
+        Assert.assertNotNull(jti2);
+        Assert.assertNotEquals(jti1, jti2);
+    }
+
+    private String doTestSignClaimsConfiguredKey(JwtClaimsBuilder builder) throws Exception {
+        String jwt = builder.sign();
 
         JsonWebSignature jws = getVerifiedJws(jwt);
         JwtClaims claims = JwtClaims.parse(jws.getPayload());
@@ -306,6 +313,7 @@ public class JwtSignTest {
         checkDefaultClaimsAndHeaders(getJwsHeaders(jwt, 2), claims);
 
         Assert.assertEquals("custom-value", claims.getClaimValue("customClaim"));
+        return claims.getJwtId();
     }
 
     @Test


### PR DESCRIPTION
Fixes #463.

Note I've added a note that the encryption builder should not be reused - this is because it operated on a `String`, example, it can already be a signed JWT.
It does not mean one can not get a unique `jti` when encrypting the tokens, it is only about recommending to avoid (not very likely to happen) pattern:
```
JwtEncryptionBuilder builder = Jwt.upn("alice").innerSign();
builder.keyId("1").encrypt();
builder.keyId("2").encrypt();
```
the same can be done by simply doing 

```
Jwt.upn("alice").innerSign().keyId("1").encrypt();
Jwt.upn("alice").innerSign().keyId("2").encrypt();
```

or

```
JwtClaimsBuilder builder = Jwt.upn("alice");
builder.innerSign().keyId("1").encrypt();
builder.innerSign().keyId("2").encrypt();
```


