### PR TITLE
Cache configured PEM keys and check configured kid for JWK keys

### DIFF
--- a/doc/modules/ROOT/pages/generate-jwt.adoc
+++ b/doc/modules/ROOT/pages/generate-jwt.adoc
@@ -140,7 +140,9 @@ Smallrye JWT supports the following properties which can be used to customize th
 |===
 |Property Name|Default|Description
 |smallrye.jwt.encrypt.key.location|none|Location of a key which will be used to encrypt the claims or inner JWT when a no-argument encrypt() method is called.
+|smallrye.jwt.encrypt.key.id|none|Encryption key identifier which is checked only when JWK keys are used.
 |smallrye.jwt.sign.key.location|none|Location of a key which will be used to sign the claims when either a no-argument sign() or innerSign() method is called.
+|smallrye.jwt.sign.key.id|none|Signing key identifier which is checked only when JWK keys are used.
 |smallrye.jwt.new-token.lifespan|300|Token lifespan in seconds which will be used to calculate an `exp` (expiry) claim value if this claim has not already been set.
 |smallrye.jwt.new-token.issuer|none|Token issuer which can be used to set an `iss` (issuer) claim value if this claim has not already been set.
 |smallrye.jwt.new-token.audience|none|Token audience which can be used to set an `aud` (audience) claim value if this claim has not already been set.

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtBuildUtils.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtBuildUtils.java
@@ -15,10 +15,15 @@ import io.smallrye.jwt.util.ResourceUtils;
  * JWT Token Build Utilities
  */
 public class JwtBuildUtils {
-    private static final String NEW_TOKEN_ISSUER = "smallrye.jwt.new-token.issuer";
-    private static final String NEW_TOKEN_AUDIENCE = "smallrye.jwt.new-token.audience";
-    private static final String NEW_TOKEN_OVERRIDE_CLAIMS = "smallrye.jwt.new-token.override-matching-claims";
-    private static final String NEW_TOKEN_LIFESPAN = "smallrye.jwt.new-token.lifespan";
+    public static final String SIGN_KEY_LOCATION_PROPERTY = "smallrye.jwt.sign.key.location";
+    public static final String SIGN_KEY_ID_PROPERTY = "smallrye.jwt.sign.key.id";
+    public static final String ENC_KEY_LOCATION_PROPERTY = "smallrye.jwt.encrypt.key.location";
+    public static final String ENC_KEY_ID_PROPERTY = "smallrye.jwt.encrypt.key.id";
+
+    public static final String NEW_TOKEN_ISSUER_PROPERTY = "smallrye.jwt.new-token.issuer";
+    public static final String NEW_TOKEN_AUDIENCE_PROPERTY = "smallrye.jwt.new-token.audience";
+    public static final String NEW_TOKEN_OVERRIDE_CLAIMS_PROPERTY = "smallrye.jwt.new-token.override-matching-claims";
+    public static final String NEW_TOKEN_LIFESPAN_PROPERTY = "smallrye.jwt.new-token.lifespan";
 
     private JwtBuildUtils() {
         // no-op: utility class
@@ -35,15 +40,15 @@ public class JwtBuildUtils {
             claims.setClaim(Claims.jti.name(), UUID.randomUUID().toString());
         }
 
-        Boolean overrideMatchingClaims = getConfigProperty(NEW_TOKEN_OVERRIDE_CLAIMS, Boolean.class);
+        Boolean overrideMatchingClaims = getConfigProperty(NEW_TOKEN_OVERRIDE_CLAIMS_PROPERTY, Boolean.class);
         if (Boolean.TRUE.equals(overrideMatchingClaims) || !claims.hasClaim(Claims.iss.name())) {
-            String issuer = getConfigProperty(NEW_TOKEN_ISSUER, String.class);
+            String issuer = getConfigProperty(NEW_TOKEN_ISSUER_PROPERTY, String.class);
             if (issuer != null) {
                 claims.setIssuer(issuer);
             }
         }
         if (Boolean.TRUE.equals(overrideMatchingClaims) || !claims.hasClaim(Claims.aud.name())) {
-            String audience = getConfigProperty(NEW_TOKEN_AUDIENCE, String.class);
+            String audience = getConfigProperty(NEW_TOKEN_AUDIENCE_PROPERTY, String.class);
             if (audience != null) {
                 claims.setAudience(audience);
             }
@@ -95,7 +100,7 @@ public class JwtBuildUtils {
             Long issuedAt = (value instanceof NumericDate) ? ((NumericDate) value).getValue() : (Long) value;
             Long lifespan = tokenLifespan;
             if (lifespan == null) {
-                lifespan = getConfigProperty(NEW_TOKEN_LIFESPAN, Long.class, 300L);
+                lifespan = getConfigProperty(NEW_TOKEN_LIFESPAN_PROPERTY, Long.class, 300L);
             }
 
             claims.setExpirationTime(NumericDate.fromSeconds(issuedAt + lifespan));

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtEncryptionImpl.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtEncryptionImpl.java
@@ -22,7 +22,6 @@ import io.smallrye.jwt.util.KeyUtils;
  * Default JWT Encryption implementation
  */
 class JwtEncryptionImpl implements JwtEncryptionBuilder {
-    private static final String KEY_LOCATION_PROPERTY = "smallrye.jwt.encrypt.key.location";
 
     boolean innerSigned;
     String claims;
@@ -181,7 +180,7 @@ class JwtEncryptionImpl implements JwtEncryptionBuilder {
     }
 
     private static String getKeyLocationFromConfig() {
-        String keyLocation = JwtBuildUtils.getConfigProperty(KEY_LOCATION_PROPERTY, String.class);
+        String keyLocation = JwtBuildUtils.getConfigProperty(JwtBuildUtils.ENC_KEY_LOCATION_PROPERTY, String.class);
         if (keyLocation != null) {
             return keyLocation;
         }
@@ -199,6 +198,12 @@ class JwtEncryptionImpl implements JwtEncryptionBuilder {
                     (algHeader == null ? KeyEncryptionAlgorithm.RSA_OAEP_256
                             : KeyEncryptionAlgorithm.fromAlgorithm(algHeader)));
             if (key == null) {
+                if (kid == null) {
+                    kid = JwtBuildUtils.getConfigProperty(JwtBuildUtils.ENC_KEY_ID_PROPERTY, String.class);
+                    if (kid != null) {
+                        headers.put("kid", kid);
+                    }
+                }
                 // Try to load JWK from a single JWK resource or JWK set resource
                 JsonWebKey jwk = KeyUtils.getJwkKeyFromJwkSet(kid, keyContent);
                 if (jwk != null) {

--- a/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtSignEncryptTest.java
+++ b/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtSignEncryptTest.java
@@ -45,13 +45,19 @@ public class JwtSignEncryptTest {
 
     @Test
     public void testSimpleInnerSignAndEncryptWithPemRsaPublicKey() throws Exception {
-        JwtClaimsBuilder builder = Jwt.claims().claim("customClaim", "custom-value");
-        String jti1 = checkRsaInnerSignedEncryptedClaims(builder.innerSign().encrypt());
-        Assert.assertNotNull(jti1);
-        String jti2 = checkRsaInnerSignedEncryptedClaims(builder.innerSign().encrypt());
-        Assert.assertNotNull(jti2);
-
-        Assert.assertNotEquals(jti1, jti2);
+        JwtBuildConfigSource configSource = getConfigSource();
+        try {
+            configSource.resetSigningKeyCallCount();
+            JwtClaimsBuilder builder = Jwt.claims().claim("customClaim", "custom-value");
+            String jti1 = checkRsaInnerSignedEncryptedClaims(builder.innerSign().encrypt());
+            Assert.assertNotNull(jti1);
+            String jti2 = checkRsaInnerSignedEncryptedClaims(builder.innerSign().encrypt());
+            Assert.assertNotNull(jti2);
+            Assert.assertNotEquals(jti1, jti2);
+            Assert.assertEquals(1, configSource.getSigningKeyCallCount());
+        } finally {
+            configSource.resetSigningKeyCallCount();
+        }
     }
 
     private String checkRsaInnerSignedEncryptedClaims(String jweCompact) throws Exception {

--- a/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtSignTest.java
+++ b/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtSignTest.java
@@ -295,12 +295,19 @@ public class JwtSignTest {
 
     @Test
     public void testSignClaimsConfiguredKey() throws Exception {
-        JwtClaimsBuilder builder = Jwt.claims().claim("customClaim", "custom-value");
-        String jti1 = doTestSignClaimsConfiguredKey(builder);
-        Assert.assertNotNull(jti1);
-        String jti2 = doTestSignClaimsConfiguredKey(builder);
-        Assert.assertNotNull(jti2);
-        Assert.assertNotEquals(jti1, jti2);
+        JwtBuildConfigSource configSource = getConfigSource();
+        try {
+            configSource.resetSigningKeyCallCount();
+            JwtClaimsBuilder builder = Jwt.claims().claim("customClaim", "custom-value");
+            String jti1 = doTestSignClaimsConfiguredKey(builder);
+            Assert.assertNotNull(jti1);
+            String jti2 = doTestSignClaimsConfiguredKey(builder);
+            Assert.assertNotNull(jti2);
+            Assert.assertNotEquals(jti1, jti2);
+            Assert.assertEquals(1, configSource.getSigningKeyCallCount());
+        } finally {
+            configSource.resetSigningKeyCallCount();
+        }
     }
 
     private String doTestSignClaimsConfiguredKey(JwtClaimsBuilder builder) throws Exception {

--- a/implementation/jwt-build/src/test/resources/privateEncryptionKeys.jwks
+++ b/implementation/jwt-build/src/test/resources/privateEncryptionKeys.jwks
@@ -1,0 +1,15 @@
+{
+"keys": [
+  {
+    "kty":"oct",
+    "k":"Fdh9u8rINxfivbrianbbVT1u232VQBZYKx1HGAGPt2I",
+    "kid": "secretkey1"
+  },
+  {
+    "kty":"oct",
+    "k":"mHgOIP5oLngqXKq0123456",
+    "kid": "secretkey3",
+    "alg": "A128KW"
+  }
+]
+}

--- a/implementation/jwt-build/src/test/resources/privateSigningKeys.jwks
+++ b/implementation/jwt-build/src/test/resources/privateSigningKeys.jwks
@@ -1,0 +1,15 @@
+{
+"keys": [
+  {
+    "kty":"oct",
+    "k":"Fdh9u8rINxfivbrianbbVT1u232VQBZYKx1HGAGPt2I",
+    "kid": "secretkey1"
+  },
+  {
+    "kty":"oct",
+    "k":"mHgOIP5oLngqXKq0jo4AkG_I0aY0nRIgAfuB8p-MW9zvxTpW9GPapkIdNcHxe5Y1lCnfVWSePazRaePg2uf9Sg",
+    "kid": "secretkey2",
+    "alg": "HS512"
+  }
+]
+}


### PR DESCRIPTION
Fixes #462

After looking at the code again I thought of addressing #462 by only caching PEM configured keys since there could be no ambiguities but decided to avoid caching JWK keys as their key identifiers can vary between the requests, in theory at least, so the only optimization when dealing with the JWK keys is when they are loaded from a multi-key JWK set - where new `smallrye.jwt.sign.key.id`/`smallrye.jwt.encrypt.key.id` can help with simplifying the code - as setting `kid` is a technical operation

I'm planning to release `3.2.0` after this PR is merged