### PR TITLE
Using the correct default key encryption algorithm

### DIFF
--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtEncryptionImpl.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtEncryptionImpl.java
@@ -162,7 +162,7 @@ class JwtEncryptionImpl implements JwtEncryptionBuilder {
         }
         if (alg == null) {
             if (keyEncryptionKey instanceof RSAPublicKey) {
-                alg = KeyEncryptionAlgorithm.RSA_OAEP_256.getAlgorithm();
+                alg = KeyEncryptionAlgorithm.RSA_OAEP.getAlgorithm();
             } else if (keyEncryptionKey instanceof SecretKey) {
                 alg = KeyEncryptionAlgorithm.A256KW.getAlgorithm();
             } else if (keyEncryptionKey instanceof ECPublicKey) {

--- a/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtEncryptTest.java
+++ b/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtEncryptTest.java
@@ -139,7 +139,7 @@ public class JwtEncryptTest {
             Jwt.claims().jwe().encrypt(key);
             Assert.fail("JwtEncryptionException is expected due to the invalid key size");
         } catch (JwtEncryptionException ex) {
-            Assert.assertEquals("SRJWT05001: A key of size 2048 bits or larger MUST be used with the 'RSA-OAEP-256' algorithm",
+            Assert.assertEquals("SRJWT05001: A key of size 2048 bits or larger MUST be used with the 'RSA-OAEP' algorithm",
                     ex.getMessage());
         }
     }
@@ -284,7 +284,7 @@ public class JwtEncryptTest {
     }
 
     private static void checkJweHeaders(String jweCompact) throws Exception {
-        checkJweHeaders(jweCompact, "RSA-OAEP-256", 3);
+        checkJweHeaders(jweCompact, "RSA-OAEP", 3);
     }
 
     private static void checkJweHeaders(String jweCompact, String keyEncKeyAlg, int size) throws Exception {
@@ -306,7 +306,7 @@ public class JwtEncryptTest {
     private static void checkRsaEncJweHeaders(String jweCompact) throws Exception {
         Map<String, Object> jweHeaders = getJweHeaders(jweCompact);
         Assert.assertEquals(2, jweHeaders.size());
-        Assert.assertEquals("RSA-OAEP-256", jweHeaders.get("alg"));
+        Assert.assertEquals("RSA-OAEP", jweHeaders.get("alg"));
         Assert.assertEquals("A256GCM", jweHeaders.get("enc"));
     }
 

--- a/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtSignEncryptTest.java
+++ b/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtSignEncryptTest.java
@@ -61,7 +61,7 @@ public class JwtSignEncryptTest {
     }
 
     private String checkRsaInnerSignedEncryptedClaims(String jweCompact) throws Exception {
-        return checkRsaInnerSignedEncryptedClaims(jweCompact, "RSA-OAEP-256");
+        return checkRsaInnerSignedEncryptedClaims(jweCompact, "RSA-OAEP");
     }
 
     private String checkRsaInnerSignedEncryptedClaims(String jweCompact, String keyEncAlgo) throws Exception {
@@ -133,7 +133,7 @@ public class JwtSignEncryptTest {
                 .keyId("key-enc-key-id")
                 .encrypt();
 
-        checkJweHeaders(jweCompact, "RSA-OAEP-256", "key-enc-key-id");
+        checkJweHeaders(jweCompact, "RSA-OAEP", "key-enc-key-id");
 
         JsonWebEncryption jwe = getJsonWebEncryption(jweCompact);
 
@@ -165,7 +165,7 @@ public class JwtSignEncryptTest {
             configSource.setEncryptionKeyLocation("/publicKey.pem");
         }
 
-        checkJweHeaders(jweCompact, "RSA-OAEP-256", "key1");
+        checkJweHeaders(jweCompact, "RSA-OAEP", "key1");
 
         JsonWebEncryption jwe = getJsonWebEncryption(jweCompact);
 

--- a/testsuite/basic/src/test/java/io/smallrye/jwt/auth/principal/DefaultJWTParserTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/jwt/auth/principal/DefaultJWTParserTest.java
@@ -124,9 +124,23 @@ public class DefaultJWTParserTest {
     @Test
     public void testDecryptWithRsaPrivateKey() throws Exception {
         String jwtString = Jwt.upn("jdoe@example.com")
-                .jwe().keyAlgorithm(KeyEncryptionAlgorithm.RSA_OAEP)
+                .jwe()
                 .encrypt(KeyUtils.readEncryptionPublicKey("/publicKey.pem"));
         JsonWebToken jwt = new DefaultJWTParser().decrypt(jwtString, KeyUtils.readDecryptionPrivateKey("/privateKey.pem"));
+        assertEquals("jdoe@example.com", jwt.getName());
+    }
+
+    @Test
+    public void testDecryptWithRsaPrivateKeyRsaOaep256() throws Exception {
+        String jwtString = Jwt.upn("jdoe@example.com")
+                .jwe().keyAlgorithm(KeyEncryptionAlgorithm.RSA_OAEP_256)
+                .encrypt(KeyUtils.readEncryptionPublicKey("/publicKey.pem"));
+
+        JWTAuthContextInfo config = new JWTAuthContextInfo();
+        config.setDecryptionKeyLocation("/privateKey.pem");
+        config.setKeyEncryptionAlgorithm(KeyEncryptionAlgorithm.RSA_OAEP_256);
+        JsonWebToken jwt = new DefaultJWTParser().parse(jwtString, config);
+
         assertEquals("jdoe@example.com", jwt.getName());
     }
 


### PR DESCRIPTION
Fixes #493

Right now the docs say it is `RSA_OAEP` while the code continues using `RSA_OAEP_256` by default - and it causes confusions when MP JWT server, assuming `RSA_OAEP` is indeed a default one, fails to decrypt.

I might do `3.3.0` after it as opposed to `3.2.2`.