### PR TITLE
Undeprecate smallrye.jwt.verify.algorithm for setting HMAC algorithms

### DIFF
--- a/implementation/jwt-auth/src/main/java/io/smallrye/jwt/config/ConfigMessages.java
+++ b/implementation/jwt-auth/src/main/java/io/smallrye/jwt/config/ConfigMessages.java
@@ -11,8 +11,8 @@ import org.jboss.logging.annotations.MessageBundle;
 interface ConfigMessages {
     ConfigMessages msg = Messages.getBundle(ConfigMessages.class);
 
-    @Message(id = 2000, value = "HS256 verification algorithm is currently not supported")
-    DeploymentException hs256NotSupported();
+    @Message(id = 2000, value = "HMAC verification algorithms are not supported when the 'mp.jwt.verify.publickey.location' property is set, use 'smallrye.jwt.verify.key.location' instead")
+    DeploymentException hmacNotSupported();
 
     @Message(id = 2001, value = "Failed to decode the MP JWT Public Key")
     DeploymentException parsingPublicKeyFailed(@Cause Throwable throwable);


### PR DESCRIPTION
Fixes #507.

Quarkus user had to set `mp.jwt.verify.publickey.algorithm=HS512` which does not look correct even though it works, so I've un-deprecated the usage of `smallrye.jwt.verify.algorithm` for setting `HS256/384/512`