### PR TITLE
Add jwt build signature and key encryption algorithm properties

### DIFF
--- a/doc/modules/ROOT/pages/generate-jwt.adoc
+++ b/doc/modules/ROOT/pages/generate-jwt.adoc
@@ -143,6 +143,8 @@ Smallrye JWT supports the following properties which can be used to customize th
 |smallrye.jwt.encrypt.key.id|none|Encryption key identifier which is checked only when JWK keys are used.
 |smallrye.jwt.sign.key.location|none|Location of a key which will be used to sign the claims when either a no-argument sign() or innerSign() method is called.
 |smallrye.jwt.sign.key.id|none|Signing key identifier which is checked only when JWK keys are used.
+|smallrye.jwt.new-token.signature-algorithm|RS256|Signature algorithm. This property will be checked if the JWT signature builder has not already set the signature algorithm.
+|smallrye.jwt.new-token.key-encryption-algorithm|RSA-OAEP|Key encryption algorithm. This property will be checked if the JWT encryption builder has not already set the key encryption algorithm.
 |smallrye.jwt.new-token.lifespan|300|Token lifespan in seconds which will be used to calculate an `exp` (expiry) claim value if this claim has not already been set.
 |smallrye.jwt.new-token.issuer|none|Token issuer which can be used to set an `iss` (issuer) claim value if this claim has not already been set.
 |smallrye.jwt.new-token.audience|none|Token audience which can be used to set an `aud` (audience) claim value if this claim has not already been set.

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/JwtEncryption.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/JwtEncryption.java
@@ -12,7 +12,8 @@ public interface JwtEncryption {
     /**
      * Encrypt the claims or inner JWT with {@link PublicKey}.
      * 'RSA-OAEP' and 'ECDH-ES+A256KW' key encryption algorithms will be used by default
-     * when public RSA or EC keys are used unless a different one has been set with {@code JwtEncryptionBuilder}.
+     * when public RSA or EC keys are used unless a different one has been set with {@code JwtEncryptionBuilder} or
+     * 'smallrye.jwt.new-token.key-encryption-algorithm' property.
      * 'A256GCM' content encryption algorithms will be used unless a different one have been set with
      * {@code JwtEncryptionBuilder}.
      * A key of size 2048 bits or larger MUST be used with the 'RSA-OAEP' and 'RSA-OAEP-256' algorithms.
@@ -26,7 +27,8 @@ public interface JwtEncryption {
     /**
      * Encrypt the claims or inner JWT with {@link SecretKey}.
      * 'A256KW' key and 'A256GCM' content encryption algorithms will be used
-     * unless different ones have been set with {@code JwtEncryptionBuilder}.
+     * unless different ones have been set with {@code JwtEncryptionBuilder} or
+     * 'smallrye.jwt.new-token.key-encryption-algorithm' property.
      *
      * @param keyEncryptionKey the key which encrypts the content encryption key
      * @return encrypted JWT token
@@ -38,7 +40,8 @@ public interface JwtEncryption {
      * Encrypt the claims or inner JWT with a public or secret key loaded from the custom location
      * which can point to a PEM, JWK or JWK set keys.
      * 'RSA-OAEP', 'ECDH-ES+A256KW' and 'A256KW' key encryption algorithms will be used by default
-     * when public RSA, EC or secret keys are used unless a different one has been set with {@code JwtEncryptionBuilder}.
+     * when public RSA, EC or secret keys are used unless a different one has been set with {@code JwtEncryptionBuilder} or
+     * 'smallrye.jwt.new-token.key-encryption-algorithm' property.
      * 'A256GCM' content encryption algorithms will be used unless a different one have been set with
      * {@code JwtEncryptionBuilder}.
      * A key of size 2048 bits or larger MUST be used with the 'RSA-OAEP' and 'RSA-OAEP-256' algorithms.
@@ -54,7 +57,8 @@ public interface JwtEncryption {
      * "smallrye.jwt.encrypt.key.location" property.
      * 
      * 'RSA-OAEP', 'ECDH-ES+A256KW' and 'A256KW' key encryption algorithms will be used by default
-     * when public RSA, EC or secret keys are used unless a different one has been set with {@code JwtEncryptionBuilder}.
+     * when public RSA, EC or secret keys are used unless a different one has been set with {@code JwtEncryptionBuilder} or
+     * 'smallrye.jwt.new-token.key-encryption-algorithm' property.
      * 'A256GCM' content encryption algorithms will be used unless a different one have been set with
      * {@code JwtEncryptionBuilder}.
      * A key of size 2048 bits or larger MUST be used with the 'RSA-OAEP' and 'RSA-OAEP-256' algorithms.
@@ -67,9 +71,9 @@ public interface JwtEncryption {
     /**
      * Encrypt the claims or inner JWT with a secret key string.
      * 'A256KW' key encryption algorithms will be used by default unless a different one has been set with
-     * {@code JwtEncryptionBuilder}.
+     * {@code JwtEncryptionBuilder} or 'smallrye.jwt.new-token.key-encryption-algorithm' property.
      * 'A256GCM' content encryption algorithms will be used unless a different one have been set with
-     * {@code JwtEncryptionBuilder}.
+     * {@code JwtEncryptionBuilder} or 'smallrye.jwt.new-token.key-encryption-algorithm' property.
      *
      * @param secret the secret
      * @return encrypted JWT token

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/JwtSignature.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/JwtSignature.java
@@ -12,7 +12,8 @@ public interface JwtSignature {
     /**
      * Sign the claims with {@link PrivateKey}.
      *
-     * 'RS256' algorithm will be used unless a different algorithm has been set with {@code JwtSignatureBuilder}.
+     * 'RS256' algorithm will be used unless a different algorithm has been set with {@code JwtSignatureBuilder} or
+     * 'smallrye.jwt.new-token.signature-algorithm' property.
      *
      * A key of size 2048 bits or larger MUST be used with the 'RS256' algorithm.
      *
@@ -25,7 +26,8 @@ public interface JwtSignature {
     /**
      * Sign the claims with {@link SecretKey}
      *
-     * 'HS256' algorithm will be used unless a different algorithm has been set with {@code JwtSignatureBuilder}.
+     * 'HS256' algorithm will be used unless a different algorithm has been set with {@code JwtSignatureBuilder} or
+     * 'smallrye.jwt.new-token.signature-algorithm' property.
      *
      * @param signingKey the signing key
      * @return signed JWT token
@@ -37,7 +39,8 @@ public interface JwtSignature {
      * Sign the claims with a private or secret key loaded from the custom location
      * which can point to a PEM, JWK or JWK set keys.
      *
-     * 'RS256' algorithm will be used unless a different algorithm has been set with {@code JwtSignatureBuilder}.
+     * 'RS256' algorithm will be used unless a different algorithm has been set with {@code JwtSignatureBuilder} or
+     * 'smallrye.jwt.new-token.signature-algorithm' property.
      * A key of size 2048 bits or larger MUST be used with the 'RS256' algorithm.
      *
      * @param keyLocation the signing key location
@@ -50,7 +53,8 @@ public interface JwtSignature {
      * Sign the claims with a key loaded from the location set with the "smallrye.jwt.sign.key.location"
      * property which can point to PEM, JWK or JWK set keys.
      *
-     * 'RS256' algorithm will be used unless a different algorithm has been set with {@code JwtSignatureBuilder}.
+     * 'RS256' algorithm will be used unless a different algorithm has been set with {@code JwtSignatureBuilder} or
+     * 'smallrye.jwt.new-token.signature-algorithm' property.
      * A key of size 2048 bits or larger MUST be used with the 'RS256' algorithm.
      *
      * @return signed JWT token
@@ -61,7 +65,8 @@ public interface JwtSignature {
     /**
      * Sign the claims with a secret key string.
      *
-     * 'HS256' algorithm will be used unless a different algorithm has been set with {@code JwtSignatureBuilder}.
+     * 'HS256' algorithm will be used unless a different algorithm has been set with {@code JwtSignatureBuilder} or
+     * 'smallrye.jwt.new-token.signature-algorithm' property.
      *
      * @param secret the secret
      * @return signed JWT token
@@ -71,7 +76,8 @@ public interface JwtSignature {
 
     /**
      * Sign the claims with {@link PrivateKey} and encrypt the inner JWT by moving to {@link JwtEncryptionBuilder}.
-     * 'RS256' algorithm will be used unless a different algorithm has been set with {@code JwtSignatureBuilder}.
+     * 'RS256' algorithm will be used unless a different algorithm has been set with {@code JwtSignatureBuilder} or
+     * 'smallrye.jwt.new-token.signature-algorithm' property.
      *
      * A key of size 2048 bits or larger MUST be used with the 'RS256' algorithm.
      *
@@ -84,7 +90,8 @@ public interface JwtSignature {
     /**
      * Sign the claims with {@link SecretKey} and encrypt the inner JWT by moving to {@link JwtEncryptionBuilder}.
      *
-     * 'HS256' algorithm will be used unless a different algorithm has been set with {@code JwtSignatureBuilder}.
+     * 'HS256' algorithm will be used unless a different algorithm has been set with {@code JwtSignatureBuilder} or
+     * 'smallrye.jwt.new-token.signature-algorithm' property.
      *
      * @param signingKey the signing key
      * @return JwtEncryption
@@ -96,7 +103,8 @@ public interface JwtSignature {
      * Sign the claims with a private or secret key loaded from the custom location
      * which can point to a PEM, JWK or JWK set keys and encrypt the inner JWT by moving to {@link JwtEncryptionBuilder}.
      *
-     * 'RS256' algorithm will be used unless a different one has been set with {@code JwtSignatureBuilder}.
+     * 'RS256' algorithm will be used unless a different one has been set with {@code JwtSignatureBuilder} or
+     * 'smallrye.jwt.new-token.signature-algorithm' property.
      * A key of size 2048 bits or larger MUST be used with the 'RS256' algorithm.
      *
      * @param keyLocation the signing key location
@@ -109,7 +117,8 @@ public interface JwtSignature {
      * Sign the claims with a key loaded from the location set with the "smallrye.jwt.sign.key.location"
      * property and encrypt the inner JWT by moving to {@link JwtEncryptionBuilder}.
      *
-     * A key of size 2048 bits or larger MUST be used with the 'RS256' algorithm.
+     * A key of size 2048 bits or larger MUST be used with the 'RS256' algorithm or 'smallrye.jwt.new-token.signature-algorithm'
+     * property.
      *
      * @return JwtEncryption
      * @throws JwtSignatureException the exception if the inner JWT signing operation has failed
@@ -118,7 +127,8 @@ public interface JwtSignature {
 
     /**
      * Sign the claims with a secret key string and encrypt the inner JWT by moving to {@link JwtEncryptionBuilder}.
-     * 'HS256' algorithm will be used unless a different one has been set with {@code JwtSignatureBuilder}.
+     * 'HS256' algorithm will be used unless a different one has been set with {@code JwtSignatureBuilder} or
+     * 'smallrye.jwt.new-token.signature-algorithm' property.
      *
      * @param secret the secret
      * @return signed JWT token

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/ImplMessages.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/ImplMessages.java
@@ -48,8 +48,8 @@ interface ImplMessages {
             + "'smallrye.jwt.sign.key.location' is not set but the 'alg' header is: %s")
     JwtSignatureException signKeyPropertyRequired(String algorithmName);
 
-    @Message(id = 5011, value = "'none' algorithm is selected but the key id 'kid' header is set")
-    JwtSignatureException signAlgorithmRequired();
+    @Message(id = 5011, value = "None signature algorithm is currently not supported")
+    JwtSignatureException noneSignatureAlgorithmUnsupported();
 
     @Message(id = 5012, value = "Failure to create a signed JWT token: %s")
     JwtSignatureException signJwtTokenFailed(String exceptionMessage, @Cause Throwable throwable);

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtBuildUtils.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtBuildUtils.java
@@ -24,6 +24,8 @@ public class JwtBuildUtils {
     public static final String NEW_TOKEN_AUDIENCE_PROPERTY = "smallrye.jwt.new-token.audience";
     public static final String NEW_TOKEN_OVERRIDE_CLAIMS_PROPERTY = "smallrye.jwt.new-token.override-matching-claims";
     public static final String NEW_TOKEN_LIFESPAN_PROPERTY = "smallrye.jwt.new-token.lifespan";
+    public static final String NEW_TOKEN_SIGNATURE_ALG_PROPERTY = "smallrye.jwt.new-token.signature-algorithm";
+    public static final String NEW_TOKEN_KEY_ENCRYPTION_ALG_PROPERTY = "smallrye.jwt.new-token.key-encryption-algorithm";
 
     private JwtBuildUtils() {
         // no-op: utility class

--- a/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtBuildConfigSource.java
+++ b/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtBuildConfigSource.java
@@ -32,11 +32,21 @@ public class JwtBuildConfigSource implements ConfigSource {
     private String signingKeyId;
     private String encryptionKeyId;
 
+    private String signatureAlg;
+
+    private String keyEncryptionAlg;
+
     @Override
     public Map<String, String> getProperties() {
         Map<String, String> map = new HashMap<>();
         map.put(JwtBuildUtils.SIGN_KEY_LOCATION_PROPERTY, signingKeyLocation);
 
+        if (signatureAlg != null) {
+            map.put(JwtBuildUtils.NEW_TOKEN_SIGNATURE_ALG_PROPERTY, signatureAlg);
+        }
+        if (keyEncryptionAlg != null) {
+            map.put(JwtBuildUtils.NEW_TOKEN_KEY_ENCRYPTION_ALG_PROPERTY, keyEncryptionAlg);
+        }
         if (encryptionKeyId != null) {
             map.put(JwtBuildUtils.ENC_KEY_ID_PROPERTY, encryptionKeyId);
         }
@@ -114,6 +124,14 @@ public class JwtBuildConfigSource implements ConfigSource {
 
     public void setEncryptonKeyId(String encryptionKeyId) {
         this.encryptionKeyId = encryptionKeyId;
+    }
+
+    public void setSignatureAlgorithm(String alg) {
+        this.signatureAlg = alg;
+    }
+
+    public void setKeyEncryptionAlgorithm(String alg) {
+        this.keyEncryptionAlg = alg;
     }
 
 }

--- a/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtEncryptTest.java
+++ b/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtEncryptTest.java
@@ -131,6 +131,45 @@ public class JwtEncryptTest {
     }
 
     @Test
+    public void testEncryptWithRsaOaep256() throws Exception {
+        String jweCompact = Jwt.claims()
+                .claim("customClaim", "custom-value")
+                .jwe().keyAlgorithm(KeyEncryptionAlgorithm.RSA_OAEP_256)
+                .keyId("key-enc-key-id")
+                .encrypt("publicKey.pem");
+
+        checkJweHeaders(jweCompact, "RSA-OAEP-256", 3);
+
+        JsonWebEncryption jwe = getJsonWebEncryption(jweCompact);
+
+        JwtClaims claims = JwtClaims.parse(jwe.getPlaintextString());
+        checkJwtClaims(claims);
+    }
+
+    @Test
+    public void testEncryptWithRsaOaep256Configured() throws Exception {
+        JwtBuildConfigSource configSource = JwtSignTest.getConfigSource();
+        configSource.setKeyEncryptionAlgorithm("RSA_OAEP_256");
+        String jweCompact = null;
+        try {
+            jweCompact = Jwt.claims()
+                    .claim("customClaim", "custom-value")
+                    .jwe()
+                    .keyId("key-enc-key-id")
+                    .encrypt("publicKey.pem");
+        } finally {
+            configSource.setKeyEncryptionAlgorithm(null);
+        }
+
+        checkJweHeaders(jweCompact, "RSA-OAEP-256", 3);
+
+        JsonWebEncryption jwe = getJsonWebEncryption(jweCompact);
+
+        JwtClaims claims = JwtClaims.parse(jwe.getPlaintextString());
+        checkJwtClaims(claims);
+    }
+
+    @Test
     public void testEncryptWithInvalidRSAKey() throws Exception {
         KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
         keyPairGenerator.initialize(1024);

--- a/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtSignPS256Test.java
+++ b/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtSignPS256Test.java
@@ -70,4 +70,26 @@ public class JwtSignPS256Test {
         Assert.assertEquals("custom-value", claims.getClaimValue("customClaim"));
     }
 
+    @Test
+    public void testSignClaimsPS256Configured() throws Exception {
+        JwtBuildConfigSource configSource = JwtSignTest.getConfigSource();
+        configSource.setSignatureAlgorithm("PS256");
+        String jwt = null;
+        try {
+            jwt = Jwt.claims()
+                    .claim("customClaim", "custom-value")
+                    .sign("/privateKey.pem");
+        } finally {
+            configSource.setSignatureAlgorithm(null);
+        }
+
+        JsonWebSignature jws = JwtSignTest.getVerifiedJws(jwt, KeyUtils.readPublicKey("/publicKey.pem"));
+        JwtClaims claims = JwtClaims.parse(jws.getPayload());
+
+        Assert.assertEquals(4, claims.getClaimsMap().size());
+        JwtSignTest.checkDefaultClaimsAndHeaders(JwtSignTest.getJwsHeaders(jwt, 2), claims, "PS256", 300);
+
+        Assert.assertEquals("custom-value", claims.getClaimValue("customClaim"));
+    }
+
 }


### PR DESCRIPTION
Fixes #514

This PR lets configure the signature and key-encryption algorithms to simplify the code; 
Also removes redundant `none` signature code - it is not supposed to be supported for a while but this code was hanging there (at some point one could inner-sign with none and then encrypt - which makes the inner-sign pointless since it is there to prove who signed the encrypted payload - so none should not have been available in the code by now anyway); and tightened a bit the encryption algorithm check the same way it is done for the signature one - to have less verbose error exceptions when the algorithm is manually set to say `A128KW` requiring a secret key while the public RSA key is provided, etc