### PR TITLE
Issue#253 Convert project to use Galleon based provisioning instead of a zip download and extraction.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,9 @@
     <version.jose4j>0.7.9</version.jose4j>
     <version.resteasy>4.7.3.Final</version.resteasy>
     <version.mokito>4.1.0</version.mokito>
+    <version.galleon>4.2.8.Final</version.galleon>
+    <version.wildfly>25.0.1.Final</version.wildfly>
+    <version.wildfly.plugin>2.1.0.Final</version.wildfly.plugin>
   </properties>
 
   <licenses>

--- a/testsuite/tck/pom.xml
+++ b/testsuite/tck/pom.xml
@@ -174,37 +174,92 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <environmentVariables>
-                <JBOSS_HOME>${project.build.directory}/wildfly-servlet-${version.wildfly}</JBOSS_HOME>
+                <JBOSS_HOME>${project.build.directory}/wildfly</JBOSS_HOME>
               </environmentVariables>
             </configuration>
           </plugin>
           <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-dependency-plugin</artifactId>
+            <groupId>org.jboss.galleon</groupId>
+            <artifactId>galleon-maven-plugin</artifactId>
+            <version>${version.galleon}</version>
             <executions>
               <execution>
-                <id>unpack</id>
-                <phase>process-test-classes</phase>
                 <goals>
-                  <goal>unpack</goal>
+                  <goal>provision</goal>
                 </goals>
                 <configuration>
-                  <artifactItems>
-                    <artifactItem>
+                  <install-dir>${project.build.directory}/wildfly</install-dir>
+                  <plugin-options>
+                    <optional-packages>passive+</optional-packages>
+                  </plugin-options>
+                  <feature-packs>
+                    <feature-pack>
                       <groupId>org.wildfly</groupId>
-                      <artifactId>wildfly-servlet-dist</artifactId>
+                      <artifactId>wildfly-galleon-pack</artifactId>
                       <version>${version.wildfly}</version>
-                      <type>zip</type>
-                      <overWrite>false</overWrite>
-                      <outputDirectory>${project.build.directory}</outputDirectory>
-                    </artifactItem>
-                  </artifactItems>
+                      <inherit-configs>false</inherit-configs>
+                      <inherit-packages>false</inherit-packages>
+                      <excluded-packages>
+                        <name>product.conf</name>
+                        <name>docs.schema</name>
+                      </excluded-packages>
+                    </feature-pack>
+                  </feature-packs>
+                  <configs>
+                    <config>
+                      <name>standalone.xml</name>
+                      <model>standalone</model>
+                      <layers>
+                          <layer>logging</layer>
+                          <layer>elytron</layer>
+                          <layer>jmx-remoting</layer> <!-- Needed for arquillian. -->
+                          <layer>management</layer>
+                          <layer>web-server</layer>
+                      </layers>
+                    </config>
+                  </configs>
                 </configuration>
               </execution>
             </executions>
           </plugin>
+          <plugin>
+            <groupId>org.wildfly.plugins</groupId>
+            <artifactId>wildfly-maven-plugin</artifactId>
+            <version>${version.wildfly.plugin}</version>
+            <executions>
+              <execution>
+                <phase>process-test-resources</phase>
+                  <goals>
+                    <goal>execute-commands</goal>
+                  </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <offline>true</offline>
+              <commands>
+                <command>embed-server</command>
+                <command>/subsystem=undertow/application-security-domain=other:add(security-domain=ApplicationDomain, integrated-jaspi=false)</command>
+              </commands>
+              <jboss-home>${project.build.directory}/wildfly</jboss-home>
+              <stdout>${project.build.directory}/wildfly-plugin.log</stdout>
+            </configuration>
+          </plugin>
         </plugins>
       </build>
+
+      <repositories>
+        <repository>
+            <id>JBoss</id>
+            <name>JBoss Repository</name>
+            <url>https://repository.jboss.org/nexus/content/groups/public-jboss/</url>
+        </repository>
+        <repository>
+            <id>Red Hat</id>
+            <name>Red Hat Repository</name>
+            <url>https://maven.repository.redhat.com/ga/</url>
+        </repository>
+      </repositories>
     </profile>
+
   </profiles>
 </project>


### PR DESCRIPTION
Additionally switch to WildFly 25.0.1.Final.

This is a follow up to https://github.com/smallrye/smallrye-jwt/pull/256

I have simplified this to the point that the provisioned server is very similar to the servlet distribution previously used.

The war which is deployed for the TCK is quite large, a follow up approach would then be to start to add Galleon layers so dependencies can move from the war ideally slimming the war to the point it only contains SmallRye artefacts. early contenders would be:

- CDI
- Rest

The EE Security integration could also be utilised which is closer to how WildFly pulls this in to enable JWT.
