### PR TITLE
Add smallrye.jwt.sign.key and smallrye.jwt.encrypt.key properties

### DIFF
--- a/doc/modules/ROOT/pages/generate-jwt.adoc
+++ b/doc/modules/ROOT/pages/generate-jwt.adoc
@@ -140,8 +140,10 @@ Smallrye JWT supports the following properties which can be used to customize th
 |===
 |Property Name|Default|Description
 |smallrye.jwt.encrypt.key.location|none|Location of a key which will be used to encrypt the claims or inner JWT when a no-argument encrypt() method is called.
+|smallrye.jwt.encrypt.key|none|Key value which will be used to encrypt the claims or inner JWT when a no-argument encrypt() method is called.
 |smallrye.jwt.encrypt.key.id|none|Encryption key identifier which is checked only when JWK keys are used.
 |smallrye.jwt.sign.key.location|none|Location of a key which will be used to sign the claims when either a no-argument sign() or innerSign() method is called.
+|smallrye.jwt.sign.key|none|Key value which will be used to sign the claims when either a no-argument sign() or innerSign() method is called.
 |smallrye.jwt.sign.key.id|none|Signing key identifier which is checked only when JWK keys are used.
 |smallrye.jwt.new-token.signature-algorithm|RS256|Signature algorithm. This property will be checked if the JWT signature builder has not already set the signature algorithm.
 |smallrye.jwt.new-token.key-encryption-algorithm|RSA-OAEP|Key encryption algorithm. This property will be checked if the JWT encryption builder has not already set the key encryption algorithm.

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/JwtEncryption.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/JwtEncryption.java
@@ -54,7 +54,8 @@ public interface JwtEncryption {
 
     /**
      * Encrypt the claims or inner JWT with a key loaded from the location set with the
-     * "smallrye.jwt.encrypt.key.location" property.
+     * "smallrye.jwt.encrypt.key.location" property or the key content set with the "smallrye.jwt.encrypt.key" property.
+     * Keys in PEM, JWK and JWK formats are supported.
      * 
      * 'RSA-OAEP', 'ECDH-ES+A256KW' and 'A256KW' key encryption algorithms will be used by default
      * when public RSA, EC or secret keys are used unless a different one has been set with {@code JwtEncryptionBuilder} or

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/JwtSignature.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/JwtSignature.java
@@ -50,8 +50,8 @@ public interface JwtSignature {
     String sign(String keyLocation) throws JwtSignatureException;
 
     /**
-     * Sign the claims with a key loaded from the location set with the "smallrye.jwt.sign.key.location"
-     * property which can point to PEM, JWK or JWK set keys.
+     * Sign the claims with a key loaded from the location set with the "smallrye.jwt.sign.key.location" property
+     * or the key content set with the "smallrye.jwt.sign.key" property. Keys in PEM, JWK and JWK formats are supported.
      *
      * 'RS256' algorithm will be used unless a different algorithm has been set with {@code JwtSignatureBuilder} or
      * 'smallrye.jwt.new-token.signature-algorithm' property.
@@ -115,7 +115,8 @@ public interface JwtSignature {
 
     /**
      * Sign the claims with a key loaded from the location set with the "smallrye.jwt.sign.key.location"
-     * property and encrypt the inner JWT by moving to {@link JwtEncryptionBuilder}.
+     * property or the key content set with the "smallrye.jwt.sign.key" property and encrypt the inner JWT
+     * by moving to {@link JwtEncryptionBuilder}. Signing keys in PEM, JWK and JWK formats are supported.
      *
      * A key of size 2048 bits or larger MUST be used with the 'RS256' algorithm or 'smallrye.jwt.new-token.signature-algorithm'
      * property.

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/ImplMessages.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/ImplMessages.java
@@ -38,8 +38,8 @@ interface ImplMessages {
     @Message(id = 5007, value = "Key encryption key can not be loaded from: %s")
     IllegalArgumentException encryptionKeyCanNotBeLoadedFromLocation(String keyLocation);
 
-    @Message(id = 5008, value = "Please set a 'smallrye.jwt.encrypt.key.location' property")
-    IllegalArgumentException encryptionKeyLocationNotConfigured();
+    @Message(id = 5008, value = "Please set 'smallrye.jwt.encrypt.key.location' or 'smallrye.jwt.encrypt.key' property")
+    IllegalArgumentException encryptionKeyNotConfigured();
 
     @Message(id = 5009, value = "")
     JwtSignatureException signatureException(@Cause Throwable throwable);
@@ -78,8 +78,8 @@ interface ImplMessages {
     @Message(id = 5020, value = "Signing key can not be loaded from: %s")
     IllegalArgumentException signingKeyCanNotBeLoadedFromLocation(String keyLocation);
 
-    @Message(id = 5021, value = "Please set a 'smallrye.jwt.sign.key.location' property")
-    IllegalArgumentException signKeyLocationNotConfigured();
+    @Message(id = 5021, value = "Please set 'smallrye.jwt.sign.key.location' or 'smallrye.jwt.sign.key' property")
+    IllegalArgumentException signKeyNotConfigured();
 
     @Message(id = 5022, value = "Failure to parse the JWT claims: %s")
     JwtException failureToParseJWTClaims(String exceptionMessage, @Cause Throwable throwable);
@@ -96,4 +96,10 @@ interface ImplMessages {
 
     @Message(id = 5027, value = "Failure to encrypt the token")
     JwtEncryptionException encryptionException(@Cause Throwable throwable);
+
+    @Message(id = 5028, value = "Signing key can not be created from the loaded content")
+    IllegalArgumentException signingKeyCanNotBeCreatedFromContent();
+
+    @Message(id = 5029, value = "Encryption key can not be created from the loaded content")
+    IllegalArgumentException encryptionKeyCanNotBeCreatedFromContent();
 }

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtBuildUtils.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtBuildUtils.java
@@ -16,8 +16,10 @@ import io.smallrye.jwt.util.ResourceUtils;
  */
 public class JwtBuildUtils {
     public static final String SIGN_KEY_LOCATION_PROPERTY = "smallrye.jwt.sign.key.location";
+    public static final String SIGN_KEY_PROPERTY = "smallrye.jwt.sign.key";
     public static final String SIGN_KEY_ID_PROPERTY = "smallrye.jwt.sign.key.id";
     public static final String ENC_KEY_LOCATION_PROPERTY = "smallrye.jwt.encrypt.key.location";
+    public static final String ENC_KEY_PROPERTY = "smallrye.jwt.encrypt.key";
     public static final String ENC_KEY_ID_PROPERTY = "smallrye.jwt.encrypt.key.id";
 
     public static final String NEW_TOKEN_ISSUER_PROPERTY = "smallrye.jwt.new-token.issuer";

--- a/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtEncryptTest.java
+++ b/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtEncryptTest.java
@@ -67,6 +67,28 @@ public class JwtEncryptTest {
     }
 
     @Test
+    public void testEncryptWithRsaPublicKeyContent() throws Exception {
+        JwtBuildConfigSource configSource = JwtSignTest.getConfigSource();
+        configSource.setUseEncryptionKeyProperty(true);
+        try {
+            String jweCompact = Jwt.claims()
+                    .claim("customClaim", "custom-value")
+                    .jwe()
+                    .keyId("key-enc-key-id")
+                    .encrypt();
+
+            checkJweHeaders(jweCompact);
+
+            JsonWebEncryption jwe = getJsonWebEncryption(jweCompact);
+
+            JwtClaims claims = JwtClaims.parse(jwe.getPlaintextString());
+            checkJwtClaims(claims);
+        } finally {
+            configSource.setUseEncryptionKeyProperty(false);
+        }
+    }
+
+    @Test
     public void testEncryptMapOfClaims() throws Exception {
         String jweCompact = Jwt.claims(Collections.singletonMap("customClaim", "custom-value"))
                 .jwe().encrypt();

--- a/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtSignTest.java
+++ b/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtSignTest.java
@@ -294,7 +294,7 @@ public class JwtSignTest {
     }
 
     @Test
-    public void testSignClaimsConfiguredKey() throws Exception {
+    public void testSignClaimsConfiguredKeyLocation() throws Exception {
         JwtBuildConfigSource configSource = getConfigSource();
         try {
             configSource.resetSigningKeyCallCount();
@@ -307,6 +307,25 @@ public class JwtSignTest {
             Assert.assertEquals(1, configSource.getSigningKeyCallCount());
         } finally {
             configSource.resetSigningKeyCallCount();
+        }
+    }
+
+    @Test
+    public void testSignClaimsConfiguredKeyContent() throws Exception {
+        JwtBuildConfigSource configSource = getConfigSource();
+        try {
+            configSource.resetSigningKeyCallCount();
+            configSource.setUseSignKeyProperty(true);
+            JwtClaimsBuilder builder = Jwt.claims().claim("customClaim", "custom-value");
+            String jti1 = doTestSignClaimsConfiguredKey(builder);
+            Assert.assertNotNull(jti1);
+            String jti2 = doTestSignClaimsConfiguredKey(builder);
+            Assert.assertNotNull(jti2);
+            Assert.assertNotEquals(jti1, jti2);
+            Assert.assertEquals(1, configSource.getSigningKeyCallCount());
+        } finally {
+            configSource.resetSigningKeyCallCount();
+            configSource.setUseSignKeyProperty(false);
         }
     }
 


### PR DESCRIPTION
Fixes #524 

This PR adds  `smallrye.jwt.sign.key` and `smallrye.jwt.encrypt.key` properties for the users be able to substitute the parameterized values of these properties with the values fetched from the external sources (example, Vault, as requested by a Quarkus user). Especially it can be of interest when signing the tokens in order to avoid managing the private keys on the local system.

PR is quite simple - for `sign()`, `innerSign()` (delegates to `sign()`) and `encrypt()` the location will be checked first and if it is not set - then the inlined content with the new properties.

Updated the tests and docs.