### PR TITLE
Add smallrye.jwt.new-token.content-encryption-algorithm property

### DIFF
--- a/doc/modules/ROOT/pages/generate-jwt.adoc
+++ b/doc/modules/ROOT/pages/generate-jwt.adoc
@@ -147,6 +147,7 @@ Smallrye JWT supports the following properties which can be used to customize th
 |smallrye.jwt.sign.key.id|none|Signing key identifier which is checked only when JWK keys are used.
 |smallrye.jwt.new-token.signature-algorithm|RS256|Signature algorithm. This property will be checked if the JWT signature builder has not already set the signature algorithm.
 |smallrye.jwt.new-token.key-encryption-algorithm|RSA-OAEP|Key encryption algorithm. This property will be checked if the JWT encryption builder has not already set the key encryption algorithm.
+|smallrye.jwt.new-token.content-encryption-algorithm|A256GCM|Content encryption algorithm. This property will be checked if the JWT encryption builder has not already set the content encryption algorithm.
 |smallrye.jwt.new-token.lifespan|300|Token lifespan in seconds which will be used to calculate an `exp` (expiry) claim value if this claim has not already been set.
 |smallrye.jwt.new-token.issuer|none|Token issuer which can be used to set an `iss` (issuer) claim value if this claim has not already been set.
 |smallrye.jwt.new-token.audience|none|Token audience which can be used to set an `aud` (audience) claim value if this claim has not already been set.

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/JwtEncryption.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/JwtEncryption.java
@@ -14,8 +14,9 @@ public interface JwtEncryption {
      * 'RSA-OAEP' and 'ECDH-ES+A256KW' key encryption algorithms will be used by default
      * when public RSA or EC keys are used unless a different one has been set with {@code JwtEncryptionBuilder} or
      * 'smallrye.jwt.new-token.key-encryption-algorithm' property.
-     * 'A256GCM' content encryption algorithms will be used unless a different one have been set with
-     * {@code JwtEncryptionBuilder}.
+     * 'A256GCM' content encryption algorithm will be used unless a different one has been set with
+     * {@code JwtEncryptionBuilder} or 'smallrye.jwt.new-token.content-encryption-algorithm' property.
+     *
      * A key of size 2048 bits or larger MUST be used with the 'RSA-OAEP' and 'RSA-OAEP-256' algorithms.
      *
      * @param keyEncryptionKey the key which encrypts the content encryption key
@@ -26,9 +27,10 @@ public interface JwtEncryption {
 
     /**
      * Encrypt the claims or inner JWT with {@link SecretKey}.
-     * 'A256KW' key and 'A256GCM' content encryption algorithms will be used
-     * unless different ones have been set with {@code JwtEncryptionBuilder} or
+     * 'A256KW' key encryption algorithm will be used unless a different one has been set with {@code JwtEncryptionBuilder} or
      * 'smallrye.jwt.new-token.key-encryption-algorithm' property.
+     * 'A256GCM' content encryption algorithm will be used unless a different one has been set with
+     * {@code JwtEncryptionBuilder} or 'smallrye.jwt.new-token.content-encryption-algorithm' property.
      *
      * @param keyEncryptionKey the key which encrypts the content encryption key
      * @return encrypted JWT token
@@ -42,8 +44,9 @@ public interface JwtEncryption {
      * 'RSA-OAEP', 'ECDH-ES+A256KW' and 'A256KW' key encryption algorithms will be used by default
      * when public RSA, EC or secret keys are used unless a different one has been set with {@code JwtEncryptionBuilder} or
      * 'smallrye.jwt.new-token.key-encryption-algorithm' property.
-     * 'A256GCM' content encryption algorithms will be used unless a different one have been set with
-     * {@code JwtEncryptionBuilder}.
+     * 'A256GCM' content encryption algorithm will be used unless a different one has been set with
+     * {@code JwtEncryptionBuilder} or 'smallrye.jwt.new-token.content-encryption-algorithm' property.
+     *
      * A key of size 2048 bits or larger MUST be used with the 'RSA-OAEP' and 'RSA-OAEP-256' algorithms.
      *
      * @param keyLocation the location of the keyEncryptionKey which encrypts the content encryption key
@@ -60,8 +63,9 @@ public interface JwtEncryption {
      * 'RSA-OAEP', 'ECDH-ES+A256KW' and 'A256KW' key encryption algorithms will be used by default
      * when public RSA, EC or secret keys are used unless a different one has been set with {@code JwtEncryptionBuilder} or
      * 'smallrye.jwt.new-token.key-encryption-algorithm' property.
-     * 'A256GCM' content encryption algorithms will be used unless a different one have been set with
-     * {@code JwtEncryptionBuilder}.
+     * 'A256GCM' content encryption algorithm will be used unless a different one have been set with
+     * {@code JwtEncryptionBuilder} or 'smallrye.jwt.new-token.content-encryption-algorithm' property.
+     *
      * A key of size 2048 bits or larger MUST be used with the 'RSA-OAEP' and 'RSA-OAEP-256' algorithms.
      *
      * @return encrypted JWT token
@@ -71,10 +75,10 @@ public interface JwtEncryption {
 
     /**
      * Encrypt the claims or inner JWT with a secret key string.
-     * 'A256KW' key encryption algorithms will be used by default unless a different one has been set with
+     * 'A256KW' key encryption algorithm will be used by default unless a different one has been set with
      * {@code JwtEncryptionBuilder} or 'smallrye.jwt.new-token.key-encryption-algorithm' property.
-     * 'A256GCM' content encryption algorithms will be used unless a different one have been set with
-     * {@code JwtEncryptionBuilder} or 'smallrye.jwt.new-token.key-encryption-algorithm' property.
+     * 'A256GCM' content encryption algorithm will be used unless a different one has been set with
+     * {@code JwtEncryptionBuilder} or 'smallrye.jwt.new-token.content-encryption-algorithm' property.
      *
      * @param secret the secret
      * @return encrypted JWT token

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtBuildUtils.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtBuildUtils.java
@@ -28,6 +28,7 @@ public class JwtBuildUtils {
     public static final String NEW_TOKEN_LIFESPAN_PROPERTY = "smallrye.jwt.new-token.lifespan";
     public static final String NEW_TOKEN_SIGNATURE_ALG_PROPERTY = "smallrye.jwt.new-token.signature-algorithm";
     public static final String NEW_TOKEN_KEY_ENCRYPTION_ALG_PROPERTY = "smallrye.jwt.new-token.key-encryption-algorithm";
+    public static final String NEW_TOKEN_CONTENT_ENCRYPTION_ALG_PROPERTY = "smallrye.jwt.new-token.content-encryption-algorithm";
 
     private JwtBuildUtils() {
         // no-op: utility class

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtEncryptionImpl.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtEncryptionImpl.java
@@ -194,7 +194,18 @@ class JwtEncryptionImpl implements JwtEncryptionBuilder {
     }
 
     private String getContentEncryptionAlgorithm() {
-        return headers.containsKey("enc") ? headers.get("enc").toString() : ContentEncryptionAlgorithm.A256GCM.name();
+        String alg = (String) headers.get("enc");
+        if (alg == null) {
+            try {
+                alg = JwtBuildUtils.getConfigProperty(JwtBuildUtils.NEW_TOKEN_CONTENT_ENCRYPTION_ALG_PROPERTY, String.class);
+                if (alg != null) {
+                    alg = ContentEncryptionAlgorithm.fromAlgorithm(alg).getAlgorithm();
+                }
+            } catch (Exception ex) {
+                throw ImplMessages.msg.unsupportedContentEncryptionAlgorithm(alg);
+            }
+        }
+        return alg != null ? alg : ContentEncryptionAlgorithm.A256GCM.name();
     }
 
     private static String getKeyContentFromLocation(String keyLocation) {

--- a/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtBuildConfigSource.java
+++ b/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtBuildConfigSource.java
@@ -35,6 +35,7 @@ public class JwtBuildConfigSource implements ConfigSource {
     private String signatureAlg;
 
     private String keyEncryptionAlg;
+    private String contentEncryptionAlg;
 
     private boolean useSignKeyProperty;
     private boolean useEncryptionKeyProperty;
@@ -66,6 +67,9 @@ public class JwtBuildConfigSource implements ConfigSource {
         }
         if (keyEncryptionAlg != null) {
             map.put(JwtBuildUtils.NEW_TOKEN_KEY_ENCRYPTION_ALG_PROPERTY, keyEncryptionAlg);
+        }
+        if (contentEncryptionAlg != null) {
+            map.put(JwtBuildUtils.NEW_TOKEN_CONTENT_ENCRYPTION_ALG_PROPERTY, contentEncryptionAlg);
         }
         if (encryptionKeyId != null) {
             map.put(JwtBuildUtils.ENC_KEY_ID_PROPERTY, encryptionKeyId);
@@ -164,6 +168,10 @@ public class JwtBuildConfigSource implements ConfigSource {
 
     public void setKeyEncryptionAlgorithm(String alg) {
         this.keyEncryptionAlg = alg;
+    }
+
+    public void setContentEncryptionAlgorithm(String alg) {
+        this.contentEncryptionAlg = alg;
     }
 
     public void setUseSignKeyProperty(boolean useSignKeyProperty) {

--- a/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtEncryptTest.java
+++ b/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtEncryptTest.java
@@ -266,6 +266,32 @@ public class JwtEncryptTest {
     }
 
     @Test
+    public void testEncryptWithConfiguredEcKeyAndContentAlgorithm() throws Exception {
+        JwtBuildConfigSource configSource = JwtSignTest.getConfigSource();
+        configSource.setEncryptionKeyLocation("/ecPublicKey.pem");
+        configSource.setContentEncryptionAlgorithm("A128CBC-HS256");
+        String jweCompact = null;
+        try {
+            jweCompact = Jwt.claims()
+                    .claim("customClaim", "custom-value")
+                    .jwe()
+                    .keyId("key-enc-key-id")
+                    .keyAlgorithm(KeyEncryptionAlgorithm.ECDH_ES_A256KW)
+                    .encrypt();
+        } finally {
+            configSource.setEncryptionKeyLocation("/publicKey.pem");
+            configSource.setContentEncryptionAlgorithm(null);
+        }
+
+        checkJweHeaders(jweCompact, "ECDH-ES+A256KW", "A128CBC-HS256", 4);
+
+        JsonWebEncryption jwe = getJsonWebEncryption(jweCompact, getEcPrivateKey());
+
+        JwtClaims claims = JwtClaims.parse(jwe.getPlaintextString());
+        checkJwtClaims(claims);
+    }
+
+    @Test
     public void testEncryptWithSecretKey() throws Exception {
         String jweCompact = Jwt.claims()
                 .claim("customClaim", "custom-value")


### PR DESCRIPTION
Fixes #519

This PR follows #514 and just adds a new property to support the content encryption algorithm; some doc typos have been fixed as well