### PR TITLE
Allow to relax the JWT build keys verification

### DIFF
--- a/doc/modules/ROOT/pages/generate-jwt.adoc
+++ b/doc/modules/ROOT/pages/generate-jwt.adoc
@@ -142,9 +142,11 @@ Smallrye JWT supports the following properties which can be used to customize th
 |smallrye.jwt.encrypt.key.location|none|Location of a key which will be used to encrypt the claims or inner JWT when a no-argument encrypt() method is called.
 |smallrye.jwt.encrypt.key|none|Key value which will be used to encrypt the claims or inner JWT when a no-argument encrypt() method is called.
 |smallrye.jwt.encrypt.key.id|none|Encryption key identifier which is checked only when JWK keys are used.
+|smallrye.jwt.encrypt.relax-key-validation|false|Relax the validation of the encryption keys
 |smallrye.jwt.sign.key.location|none|Location of a key which will be used to sign the claims when either a no-argument sign() or innerSign() method is called.
 |smallrye.jwt.sign.key|none|Key value which will be used to sign the claims when either a no-argument sign() or innerSign() method is called.
 |smallrye.jwt.sign.key.id|none|Signing key identifier which is checked only when JWK keys are used.
+|smallrye.jwt.sign.relax-key-validation|false|Relax the validation of the signing keys
 |smallrye.jwt.new-token.signature-algorithm|RS256|Signature algorithm. This property will be checked if the JWT signature builder has not already set the signature algorithm.
 |smallrye.jwt.new-token.key-encryption-algorithm|RSA-OAEP|Key encryption algorithm. This property will be checked if the JWT encryption builder has not already set the key encryption algorithm.
 |smallrye.jwt.new-token.content-encryption-algorithm|A256GCM|Content encryption algorithm. This property will be checked if the JWT encryption builder has not already set the content encryption algorithm.

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/ImplMessages.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/ImplMessages.java
@@ -19,10 +19,6 @@ interface ImplMessages {
 
     JwtSignatureException unsupportedSignatureAlgorithm(String algorithmName);
 
-    @Message(id = 5001, value = "A key of size 2048 bits or larger MUST be used with " +
-            "the '%s' algorithm")
-    JwtEncryptionException encryptionKeySizeMustBeHigher(String algorithmName);
-
     @Message(id = 5003, value = "%s")
     JwtEncryptionException joseSerializationError(String errorMessage, @Cause Throwable t);
 

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtBuildUtils.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtBuildUtils.java
@@ -18,9 +18,11 @@ public class JwtBuildUtils {
     public static final String SIGN_KEY_LOCATION_PROPERTY = "smallrye.jwt.sign.key.location";
     public static final String SIGN_KEY_PROPERTY = "smallrye.jwt.sign.key";
     public static final String SIGN_KEY_ID_PROPERTY = "smallrye.jwt.sign.key.id";
+    public static final String SIGN_KEY_RELAX_VALIDATION_PROPERTY = "smallrye.jwt.sign.relax-key-validation";
     public static final String ENC_KEY_LOCATION_PROPERTY = "smallrye.jwt.encrypt.key.location";
     public static final String ENC_KEY_PROPERTY = "smallrye.jwt.encrypt.key";
     public static final String ENC_KEY_ID_PROPERTY = "smallrye.jwt.encrypt.key.id";
+    public static final String ENC_KEY_RELAX_VALIDATION_PROPERTY = "smallrye.jwt.encrypt.relax-key-validation";
 
     public static final String NEW_TOKEN_ISSUER_PROPERTY = "smallrye.jwt.new-token.issuer";
     public static final String NEW_TOKEN_AUDIENCE_PROPERTY = "smallrye.jwt.new-token.audience";

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtSignatureImpl.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtSignatureImpl.java
@@ -144,11 +144,18 @@ class JwtSignatureImpl implements JwtSignature {
 
         jws.setPayload(claims.toJson());
         jws.setKey(signingKey);
+        if (isRelaxKeyValidation()) {
+            jws.setDoKeyValidation(false);
+        }
         try {
             return jws.getCompactSerialization();
         } catch (Exception ex) {
             throw ImplMessages.msg.signJwtTokenFailed(ex.getMessage(), ex);
         }
+    }
+
+    private boolean isRelaxKeyValidation() {
+        return JwtBuildUtils.getConfigProperty(JwtBuildUtils.SIGN_KEY_RELAX_VALIDATION_PROPERTY, Boolean.class, false);
     }
 
     private String getSignatureAlgorithm(Key signingKey) {
@@ -200,7 +207,7 @@ class JwtSignatureImpl implements JwtSignature {
 
         String keyLocation = JwtBuildUtils.getConfigProperty(JwtBuildUtils.SIGN_KEY_LOCATION_PROPERTY, String.class);
         if (keyLocation != null) {
-            return getKeyContentFromLocation(keyLocation);
+            return getKeyContentFromLocation(keyLocation.trim());
         }
         String keyContent = JwtBuildUtils.getConfigProperty(JwtBuildUtils.SIGN_KEY_PROPERTY, String.class);
         if (keyContent != null) {

--- a/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtBuildConfigSource.java
+++ b/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtBuildConfigSource.java
@@ -15,6 +15,8 @@ public class JwtBuildConfigSource implements ConfigSource {
 
     private static final Set<String> PROPERTY_NAMES = new HashSet<>(Arrays.asList(
             JwtBuildUtils.SIGN_KEY_ID_PROPERTY,
+            JwtBuildUtils.SIGN_KEY_RELAX_VALIDATION_PROPERTY,
+            JwtBuildUtils.ENC_KEY_RELAX_VALIDATION_PROPERTY,
             JwtBuildUtils.ENC_KEY_ID_PROPERTY,
             JwtBuildUtils.NEW_TOKEN_ISSUER_PROPERTY,
             JwtBuildUtils.NEW_TOKEN_AUDIENCE_PROPERTY,
@@ -39,6 +41,9 @@ public class JwtBuildConfigSource implements ConfigSource {
 
     private boolean useSignKeyProperty;
     private boolean useEncryptionKeyProperty;
+
+    private boolean relaxSignatureKeyValidation;
+    private boolean relaxEncryptionKeyValidation;
 
     @Override
     public Map<String, String> getProperties() {
@@ -86,6 +91,14 @@ public class JwtBuildConfigSource implements ConfigSource {
         }
         if (audiencePropertyRequired) {
             map.put(JwtBuildUtils.NEW_TOKEN_AUDIENCE_PROPERTY, "https://custom-audience");
+        }
+
+        if (relaxSignatureKeyValidation) {
+            map.put(JwtBuildUtils.SIGN_KEY_RELAX_VALIDATION_PROPERTY, String.valueOf(relaxSignatureKeyValidation));
+        }
+
+        if (relaxEncryptionKeyValidation) {
+            map.put(JwtBuildUtils.ENC_KEY_RELAX_VALIDATION_PROPERTY, String.valueOf(relaxEncryptionKeyValidation));
         }
 
         map.put(JwtBuildUtils.NEW_TOKEN_OVERRIDE_CLAIMS_PROPERTY, String.valueOf(overrideMatchingClaims));
@@ -180,6 +193,15 @@ public class JwtBuildConfigSource implements ConfigSource {
 
     public void setUseEncryptionKeyProperty(boolean useEncryptionKeyProperty) {
         this.useEncryptionKeyProperty = useEncryptionKeyProperty;
+    }
+
+    public void setRelaxSignatureKeyValidation(boolean relax) {
+        this.relaxSignatureKeyValidation = relax;
+
+    }
+
+    public void setRelaxEncryptionKeyValidation(boolean relax) {
+        this.relaxEncryptionKeyValidation = relax;
     }
 
 }


### PR DESCRIPTION
Fixes #552 (to let users relax the verification when they have no control over choosing the keys/secrets. Note I've dropped an explicit RSA key check from the encryption code as it is done now by Jose4J itself - which has also been the case with the signature implementation - I think I may've forgotten to remove it earlier)
Fixes #535 (just trimming the location values as one user had some space and could not load the keys)

This is the last update I'd like to do before releasing 3.3.3