### PR TITLE
Run TCK with Jetty

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - jakarta
     paths-ignore:
       - '.gitignore'
       - 'CODEOWNERS'

--- a/pom.xml
+++ b/pom.xml
@@ -36,12 +36,22 @@
     <bouncycastle.version>1.70</bouncycastle.version>
     <version.jakarta.servlet.api>4.0.4</version.jakarta.servlet.api>
     <version.jakarta.security.enterprise.api>1.0.2</version.jakarta.security.enterprise.api>
-    <version.io.smallrye.config>2.8.2</version.io.smallrye.config>
     <version.eclipse.microprofile.jwt>1.2.2</version.eclipse.microprofile.jwt>
     <version.microprofile.config>2.0</version.microprofile.config>
     <version.jose4j>0.7.9</version.jose4j>
+    <version.mokito>4.2.0</version.mokito>
+
+    <!-- Test -->
+    <artifactId.arquillian.jetty>arquillian-jetty-embedded-9</artifactId.arquillian.jetty>
+    <version.arquillian.jetty>1.0.0.CR4</version.arquillian.jetty>
+    <version.jetty>9.4.44.v20210927</version.jetty>
     <version.resteasy>4.7.5.Final</version.resteasy>
-    <version.mokito>4.3.0</version.mokito>
+    <version.smallrye.config>2.8.2</version.smallrye.config>
+    <!-- RESTEasy REST Client relocated to another GAV, so these props are for jakarta auto migration -->
+    <groupId.resteasy.client>org.jboss.resteasy</groupId.resteasy.client>
+    <artifactId.resteasy.client>resteasy-client-microprofile</artifactId.resteasy.client>
+    <version.resteasy.client>4.7.5.Final</version.resteasy.client>
+    <!-- Wildfly -->
     <version.galleon>4.2.8.Final</version.galleon>
     <version.wildfly>25.0.1.Final</version.wildfly>
     <version.wildfly.plugin>2.1.0.Final</version.wildfly.plugin>
@@ -149,6 +159,7 @@
         <artifactId>smallrye-jwt-cdi-extension</artifactId>
         <version>${project.version}</version>
       </dependency>
+
       <!-- Unit/Integration test dependencies -->
       <dependency>
         <groupId>org.mockito</groupId>
@@ -156,14 +167,42 @@
         <version>${version.mokito}</version>
       </dependency>
       <dependency>
-        <groupId>io.smallrye.config</groupId>
-        <artifactId>smallrye-config</artifactId>
-        <version>${version.io.smallrye.config}</version>
-      </dependency>
-      <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcprov-jdk15on</artifactId>
         <version>${bouncycastle.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.arquillian.container</groupId>
+        <artifactId>${artifactId.arquillian.jetty}</artifactId>
+        <version>${version.arquillian.jetty}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-bom</artifactId>
+        <version>${version.jetty}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.weld.servlet</groupId>
+        <artifactId>weld-servlet-core</artifactId>
+        <version>${version.weld.core}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.resteasy</groupId>
+        <artifactId>resteasy-bom</artifactId>
+        <version>${version.resteasy}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.smallrye.config</groupId>
+        <artifactId>smallrye-config</artifactId>
+        <version>${version.smallrye.config}</version>
+        <scope>test</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/testsuite/tck/pom.xml
+++ b/testsuite/tck/pom.xml
@@ -29,6 +29,14 @@
   <name>SmallRye: MicroProfile JWT TCK</name>
 
   <dependencies>
+    <!-- Tests -->
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Implementation -->
     <dependency>
       <groupId>io.smallrye</groupId>
       <artifactId>smallrye-jwt</artifactId>
@@ -41,51 +49,8 @@
       <groupId>io.smallrye</groupId>
       <artifactId>smallrye-jwt-cdi-extension</artifactId>
     </dependency>
-    <dependency>
-      <groupId>io.smallrye.config</groupId>
-      <artifactId>smallrye-config</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.weld.servlet</groupId>
-      <artifactId>weld-servlet-core</artifactId>
-      <version>${version.weld.core}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.resteasy</groupId>
-      <artifactId>resteasy-servlet-initializer</artifactId>
-      <version>${version.resteasy}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.resteasy</groupId>
-      <artifactId>resteasy-undertow</artifactId>
-      <version>${version.resteasy}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.jboss.threads</groupId>
-          <artifactId>jboss-threads</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.resteasy</groupId>
-      <artifactId>resteasy-client</artifactId>
-      <version>${version.resteasy}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.resteasy</groupId>
-      <artifactId>resteasy-cdi</artifactId>
-      <version>${version.resteasy}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.resteasy</groupId>
-      <artifactId>resteasy-json-binding-provider</artifactId>
-      <version>${version.resteasy}</version>
-    </dependency>
+
+    <!-- TCK -->
     <dependency>
       <groupId>org.eclipse.microprofile.jwt</groupId>
       <artifactId>microprofile-jwt-auth-tck</artifactId>
@@ -96,9 +61,37 @@
       <type>test-jar</type>
     </dependency>
 
+    <!-- Container -->
     <dependency>
-      <groupId>org.jboss.arquillian.container</groupId>
-      <artifactId>arquillian-container-spi</artifactId>
+      <groupId>org.jboss.weld.servlet</groupId>
+      <artifactId>weld-servlet-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-servlet-initializer</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-cdi</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-json-binding-provider</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>${groupId.resteasy.client}</groupId>
+      <artifactId>${artifactId.resteasy.client}</artifactId>
+      <version>${version.resteasy.client}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.smallrye.config</groupId>
+      <artifactId>smallrye-config</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 
@@ -118,6 +111,7 @@
             <!--suppress UnresolvedMavenProperty -->
             <!-- So we can pass the jacoco agent to the Arquillian VM Options. See arquillian.xml -->
             <jacocoArgLine>${jacocoArgLine}</jacocoArgLine>
+            <mp.jwt.tck.jwks.baseURL>http://localhost:9090</mp.jwt.tck.jwks.baseURL>
           </systemPropertyVariables>
         </configuration>
       </plugin>
@@ -153,20 +147,65 @@
 
   <profiles>
     <profile>
-      <id>wildfly-servlet</id>
+      <id>jetty</id>
       <activation>
         <property>
-          <!-- use property rather than activeByDefault, see https://issues.apache.org/jira/browse/MNG-4917 -->
-          <name>!noWildflyServlet</name>
+          <name>!noJetty</name>
         </property>
       </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <environmentVariables>
+                <mp.jwt.tck.jwks.baseURL>http://localhost:9090</mp.jwt.tck.jwks.baseURL>
+              </environmentVariables>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
       <dependencies>
         <dependency>
-          <groupId>org.wildfly.arquillian</groupId>
-          <artifactId>wildfly-arquillian-container-managed</artifactId>
+          <groupId>org.jboss.arquillian.container</groupId>
+          <artifactId>${artifactId.arquillian.jetty}</artifactId>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.jboss.shrinkwrap.resolver</groupId>
+          <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.jboss.shrinkwrap.resolver</groupId>
+          <artifactId>shrinkwrap-resolver-api-maven</artifactId>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-webapp</artifactId>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-deploy</artifactId>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-annotations</artifactId>
           <scope>test</scope>
         </dependency>
       </dependencies>
+    </profile>
+    <profile>
+      <id>wildfly</id>
+      <activation>
+        <property>
+          <name>wildfly</name>
+        </property>
+      </activation>
       <build>
         <plugins>
           <plugin>
@@ -176,6 +215,9 @@
               <environmentVariables>
                 <JBOSS_HOME>${project.build.directory}/wildfly</JBOSS_HOME>
               </environmentVariables>
+              <systemPropertyVariables>
+                <mp.jwt.tck.jwks.baseURL>http://localhost:8080</mp.jwt.tck.jwks.baseURL>
+              </systemPropertyVariables>
             </configuration>
           </plugin>
           <plugin>
@@ -246,6 +288,19 @@
           </plugin>
         </plugins>
       </build>
+
+      <dependencies>
+        <dependency>
+          <groupId>org.wildfly.arquillian</groupId>
+          <artifactId>wildfly-arquillian-container-managed</artifactId>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.jboss.weld.servlet</groupId>
+          <artifactId>weld-servlet-core</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
 
       <repositories>
         <repository>

--- a/testsuite/tck/src/test/java/io/smallrye/jwt/tck/SmallRyeJWTArchiveProcessor.java
+++ b/testsuite/tck/src/test/java/io/smallrye/jwt/tck/SmallRyeJWTArchiveProcessor.java
@@ -1,12 +1,15 @@
 package io.smallrye.jwt.tck;
 
 import java.io.File;
+import java.util.Map;
 
 import javax.enterprise.inject.spi.Extension;
 
 import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
 import org.jboss.arquillian.test.spi.TestClass;
 import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ArchivePath;
+import org.jboss.shrinkwrap.api.Node;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 
@@ -19,28 +22,35 @@ public class SmallRyeJWTArchiveProcessor implements ApplicationArchiveProcessor 
             war.addClass(SmallRyeJWTAuthJaxRsFeature.class);
             war.addAsServiceProvider(Extension.class, OptionalAwareSmallRyeJWTAuthCDIExtension.class);
 
+            // MP Config in wrong place - See https://github.com/eclipse/microprofile/issues/46.
+            Map<ArchivePath, Node> content = war.getContent(object -> object.get().matches(".*META-INF/.*"));
+            content.forEach((archivePath, node) -> {
+                if (node.getAsset() != null) {
+                    war.addAsResource(node.getAsset(), node.getPath());
+                }
+            });
+
             if (!war.contains("META-INF/microprofile-config.properties")) {
-                war.addAsManifestResource("microprofile-config-local.properties", "microprofile-config.properties");
+                war.addAsWebInfResource("microprofile-config-local.properties", "microprofile-config.properties");
             }
 
             // A few tests require the apps to be deployed in the root. Check PublicKeyAsJWKLocationURLTest and PublicKeyAsPEMLocationURLTest
             // Both tests set the public key location url to be in root.
             war.addAsWebInfResource("jboss-web.xml");
+            war.addAsWebInfResource("jetty-web.xml");
 
             String[] deps = {
-                    "io.smallrye:smallrye-jwt",
-                    "io.smallrye:smallrye-jwt-jaxrs",
-                    "io.smallrye:smallrye-jwt-cdi-extension",
-                    "io.smallrye.config:smallrye-config",
                     "org.jboss.resteasy:resteasy-servlet-initializer",
-                    "org.jboss.resteasy:resteasy-undertow",
-                    "org.jboss.resteasy:resteasy-client",
                     "org.jboss.resteasy:resteasy-cdi",
                     "org.jboss.resteasy:resteasy-json-binding-provider",
-                    "org.jboss.weld.servlet:weld-servlet-core"
+                    "org.jboss.weld.servlet:weld-servlet-core",
+                    "commons-io:commons-io:2.11.0",
+                    "io.smallrye:smallrye-jwt",
+                    "io.smallrye:smallrye-jwt-jaxrs",
+                    "io.smallrye:smallrye-jwt-cdi-extension"
             };
             File[] dependencies = Maven.resolver()
-                    .loadPomFromFile(new File("pom.xml"))
+                    .loadPomFromFile(new File("pom.xml"), "jetty", "wildfly")
                     .resolve(deps)
                     .withTransitivity()
                     .asFile();

--- a/testsuite/tck/src/test/resources/jetty-web.xml
+++ b/testsuite/tck/src/test/resources/jetty-web.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure.dtd">
+<Configure class="org.eclipse.jetty.webapp.WebAppContext">
+    <Set name="contextPath">/</Set>
+</Configure>


### PR DESCRIPTION
This allows running the TCK with Jetty

The motivation is to be able to run the TCK with Jakarta, since there is no release with source-based Jakarta for Wildfly.

https://github.com/smallrye/smallrye-jwt/tree/jakarta