### PR TITLE
Support for TLS certificates and hostname verification

### DIFF
--- a/doc/modules/ROOT/pages/configuration.adoc
+++ b/doc/modules/ROOT/pages/configuration.adoc
@@ -61,6 +61,9 @@ SmallRye JWT supports many properties which can be used to customize the token p
 |smallrye.jwt.decrypt.key.location|none|Config property allows for an external or internal location of Private Decryption Key to be specified. This property is deprecated, use `mp.jwt.decrypt.key.location`.
 |smallrye.jwt.decrypt.algorithm|`RSA_OAEP`|Decryption algorithm.
 |smallrye.jwt.token.decryption.kid|none|Decryption Key identifier. If it is set then the decryption JWK key as well every JWT token must have a matching `kid` header.
+|smallrye.jwt.tls.certificate.path|none|Path to TLS trusted certificate which may need to be configured if the keys have to be fetched over `HTTPS`.
+|smallrye.jwt.tls.trust-all|false|Trust all the hostnames. If the keys have to be fetched over `HTTPS` and this property is set to `true` then all the hostnames are trusted by default.
+|smallrye.jwt.tls.trusted.hosts|none|Set of trusted hostnames. If the keys have to be fetched over `HTTPS` and `smallrye.jwt.tls.trust-all` is set to `false` then then this property can be used to configure the trusted hostnames.
 |===
 
 = Create JsonWebToken with JWTParser

--- a/implementation/jwt-auth/src/main/java/io/smallrye/jwt/auth/principal/JWTAuthContextInfo.java
+++ b/implementation/jwt-auth/src/main/java/io/smallrye/jwt/auth/principal/JWTAuthContextInfo.java
@@ -64,6 +64,9 @@ public class JWTAuthContextInfo {
     private Set<String> requiredClaims;
     private boolean relaxVerificationKeyValidation = true;
     private boolean verifyCertificateThumbprint;
+    private String tlsCertificatePath;
+    private Set<String> tlsTrustedHosts;
+    private boolean tlsTrustAll;
 
     public JWTAuthContextInfo() {
     }
@@ -121,6 +124,9 @@ public class JWTAuthContextInfo {
         this.requiredClaims = orig.getRequiredClaims();
         this.relaxVerificationKeyValidation = orig.isRelaxVerificationKeyValidation();
         this.verifyCertificateThumbprint = orig.isVerifyCertificateThumbprint();
+        this.tlsCertificatePath = orig.getTlsCertificatePath();
+        this.tlsTrustedHosts = orig.getTlsTrustedHosts();
+        this.tlsTrustAll = orig.isTlsTrustAll();
     }
 
     @Deprecated
@@ -423,5 +429,29 @@ public class JWTAuthContextInfo {
 
     public void setVerifyCertificateThumbprint(boolean verifyCertificateThumbprint) {
         this.verifyCertificateThumbprint = verifyCertificateThumbprint;
+    }
+
+    public String getTlsCertificatePath() {
+        return tlsCertificatePath;
+    }
+
+    public void setTlsCertificatePath(String tlsCertificatePath) {
+        this.tlsCertificatePath = tlsCertificatePath;
+    }
+
+    public Set<String> getTlsTrustedHosts() {
+        return tlsTrustedHosts;
+    }
+
+    public void setTlsTrustedHosts(Set<String> tlsTrustedHosts) {
+        this.tlsTrustedHosts = tlsTrustedHosts;
+    }
+
+    public void setTlsTrustAll(boolean tlsTrustAll) {
+        this.tlsTrustAll = tlsTrustAll;
+    }
+
+    public boolean isTlsTrustAll() {
+        return this.tlsTrustAll;
     }
 }

--- a/implementation/jwt-auth/src/main/java/io/smallrye/jwt/config/JWTAuthContextInfoProvider.java
+++ b/implementation/jwt-auth/src/main/java/io/smallrye/jwt/config/JWTAuthContextInfoProvider.java
@@ -128,6 +128,8 @@ public class JWTAuthContextInfoProvider {
         provider.expectedAudience = Optional.empty();
         provider.groupsSeparator = DEFAULT_GROUPS_SEPARATOR;
         provider.requiredClaims = Optional.empty();
+        provider.tlsCertificatePath = Optional.empty();
+        provider.tlsTrustedHosts = Optional.empty();
 
         return provider;
     }
@@ -406,6 +408,28 @@ public class JWTAuthContextInfoProvider {
     @ConfigProperty(name = "smallrye.jwt.required.claims")
     Optional<Set<String>> requiredClaims;
 
+    /**
+     * TLS Trusted Certificate Path.
+     */
+    @Inject
+    @ConfigProperty(name = "smallrye.jwt.tls.certificate.path")
+    private Optional<String> tlsCertificatePath;
+
+    /**
+     * TLS Trust All.
+     * If this property is set to 'true' then HTTPS HostnameVerifier will trust all the hostnames.
+     */
+    @Inject
+    @ConfigProperty(name = "smallrye.jwt.tls.trust-all", defaultValue = "false")
+    private boolean tlsTrustAll;
+
+    /**
+     * TLS Trusted Hosts. Set this property if `smallrye.jwt.tls.trust-all` property is disabled.
+     */
+    @Inject
+    @ConfigProperty(name = "smallrye.jwt.tls.hosts")
+    private Optional<Set<String>> tlsTrustedHosts;
+
     @Produces
     Optional<JWTAuthContextInfo> getOptionalContextInfo() {
         String resolvedVerifyKeyLocation = !NONE.equals(verifyKeyLocation)
@@ -489,6 +513,9 @@ public class JWTAuthContextInfoProvider {
         contextInfo.setDefaultSubjectClaim(defaultSubClaim.orElse(null));
         SmallryeJwtUtils.setContextSubPath(contextInfo, subPath);
         contextInfo.setDefaultGroupsClaim(defaultGroupsClaim.orElse(null));
+        contextInfo.setTlsCertificatePath(tlsCertificatePath.orElse(null));
+        contextInfo.setTlsTrustedHosts(tlsTrustedHosts.orElse(null));
+        contextInfo.setTlsTrustAll(tlsTrustAll);
         SmallryeJwtUtils.setContextGroupsPath(contextInfo, groupsPath);
         contextInfo.setExpGracePeriodSecs(expGracePeriodSecs);
         contextInfo.setMaxTimeToLiveSecs(maxTimeToLiveSecs.orElse(null));


### PR DESCRIPTION
Fixes #571
Fixes #581

Currently only certificates in PEM format are supported and read from the file, but in the future we can support loading them from the truststores 

CC @kdubb