### PR TITLE
Support for HTTP Proxy

### DIFF
--- a/doc/modules/ROOT/pages/configuration.adoc
+++ b/doc/modules/ROOT/pages/configuration.adoc
@@ -64,6 +64,8 @@ SmallRye JWT supports many properties which can be used to customize the token p
 |smallrye.jwt.tls.certificate.path|none|Path to TLS trusted certificate which may need to be configured if the keys have to be fetched over `HTTPS`.
 |smallrye.jwt.tls.trust-all|false|Trust all the hostnames. If the keys have to be fetched over `HTTPS` and this property is set to `true` then all the hostnames are trusted by default.
 |smallrye.jwt.tls.trusted.hosts|none|Set of trusted hostnames. If the keys have to be fetched over `HTTPS` and `smallrye.jwt.tls.trust-all` is set to `false` then then this property can be used to configure the trusted hostnames.
+|smallrye.jwt.http.proxy.host|none|HTTP proxy host.
+|smallrye.jwt.http.proxy.port|80|HTTP proxy port.
 |===
 
 = Create JsonWebToken with JWTParser

--- a/implementation/jwt-auth/src/main/java/io/smallrye/jwt/auth/principal/JWTAuthContextInfo.java
+++ b/implementation/jwt-auth/src/main/java/io/smallrye/jwt/auth/principal/JWTAuthContextInfo.java
@@ -67,6 +67,8 @@ public class JWTAuthContextInfo {
     private String tlsCertificatePath;
     private Set<String> tlsTrustedHosts;
     private boolean tlsTrustAll;
+    private String httpProxyHost;
+    private int httpProxyPort;
 
     public JWTAuthContextInfo() {
     }
@@ -127,6 +129,8 @@ public class JWTAuthContextInfo {
         this.tlsCertificatePath = orig.getTlsCertificatePath();
         this.tlsTrustedHosts = orig.getTlsTrustedHosts();
         this.tlsTrustAll = orig.isTlsTrustAll();
+        this.httpProxyHost = orig.getHttpProxyHost();
+        this.httpProxyPort = orig.getHttpProxyPort();
     }
 
     @Deprecated
@@ -412,6 +416,11 @@ public class JWTAuthContextInfo {
                 ", groupsSeparator='" + groupsSeparator + '\'' +
                 ", relaxVerificationKeyValidation=" + relaxVerificationKeyValidation +
                 ", verifyCertificateThumbprint=" + verifyCertificateThumbprint +
+                ", tlsCertificatePath=" + tlsCertificatePath +
+                ", tlsTrustAll=" + tlsTrustAll +
+                ", tlsTrustedHosts=" + tlsTrustedHosts +
+                ", httpProxyHost=" + httpProxyHost +
+                ", httpProxyPort=" + httpProxyPort +
                 '}';
     }
 
@@ -453,5 +462,21 @@ public class JWTAuthContextInfo {
 
     public boolean isTlsTrustAll() {
         return this.tlsTrustAll;
+    }
+
+    public String getHttpProxyHost() {
+        return httpProxyHost;
+    }
+
+    public void setHttpProxyHost(String httpProxyHost) {
+        this.httpProxyHost = httpProxyHost;
+    }
+
+    public int getHttpProxyPort() {
+        return httpProxyPort;
+    }
+
+    public void setHttpProxyPort(int httpProxyPort) {
+        this.httpProxyPort = httpProxyPort;
     }
 }

--- a/implementation/jwt-auth/src/main/java/io/smallrye/jwt/config/JWTAuthContextInfoProvider.java
+++ b/implementation/jwt-auth/src/main/java/io/smallrye/jwt/config/JWTAuthContextInfoProvider.java
@@ -130,6 +130,8 @@ public class JWTAuthContextInfoProvider {
         provider.requiredClaims = Optional.empty();
         provider.tlsCertificatePath = Optional.empty();
         provider.tlsTrustedHosts = Optional.empty();
+        provider.httpProxyHost = Optional.empty();
+        provider.httpProxyPort = 80;
 
         return provider;
     }
@@ -430,6 +432,20 @@ public class JWTAuthContextInfoProvider {
     @ConfigProperty(name = "smallrye.jwt.tls.hosts")
     private Optional<Set<String>> tlsTrustedHosts;
 
+    /**
+     * HTTP Proxy Host.
+     */
+    @Inject
+    @ConfigProperty(name = "smallrye.jwt.http.proxy.host")
+    private Optional<String> httpProxyHost;
+
+    /**
+     * HTTP Proxy Port.
+     */
+    @Inject
+    @ConfigProperty(name = "smallrye.jwt.http.proxy.port", defaultValue = "80")
+    private int httpProxyPort = 80;
+
     @Produces
     Optional<JWTAuthContextInfo> getOptionalContextInfo() {
         String resolvedVerifyKeyLocation = !NONE.equals(verifyKeyLocation)
@@ -516,6 +532,8 @@ public class JWTAuthContextInfoProvider {
         contextInfo.setTlsCertificatePath(tlsCertificatePath.orElse(null));
         contextInfo.setTlsTrustedHosts(tlsTrustedHosts.orElse(null));
         contextInfo.setTlsTrustAll(tlsTrustAll);
+        contextInfo.setHttpProxyHost(httpProxyHost.orElse(null));
+        contextInfo.setHttpProxyPort(httpProxyPort);
         SmallryeJwtUtils.setContextGroupsPath(contextInfo, groupsPath);
         contextInfo.setExpGracePeriodSecs(expGracePeriodSecs);
         contextInfo.setMaxTimeToLiveSecs(maxTimeToLiveSecs.orElse(null));

--- a/implementation/jwt-auth/src/test/java/io/smallrye/jwt/auth/principal/KeyLocationResolverTest.java
+++ b/implementation/jwt-auth/src/test/java/io/smallrye/jwt/auth/principal/KeyLocationResolverTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
+import java.net.Proxy;
 import java.nio.charset.StandardCharsets;
 import java.security.cert.X509Certificate;
 import java.security.interfaces.RSAPublicKey;
@@ -150,10 +151,11 @@ public class KeyLocationResolverTest {
     }
 
     @Test
-    public void testLoadRsaKeyFromHttpsJwksWithCertPathAndTrustedHosts() throws Exception {
+    public void testLoadRsaKeyFromHttpsJwksWithCertPathAndTrustedHostsAndProxy() throws Exception {
         JWTAuthContextInfo contextInfo = new JWTAuthContextInfo("https://github.com/my_key.jwks", "issuer");
         contextInfo.setTlsCertificatePath("publicCrt.pem");
         contextInfo.setTlsTrustedHosts(new HashSet<>(Arrays.asList("trusted-host")));
+        contextInfo.setHttpProxyHost("proxyhost");
         contextInfo.setJwksRefreshInterval(10);
 
         KeyLocationResolver keyLocationResolver = new KeyLocationResolver(contextInfo) {
@@ -168,6 +170,7 @@ public class KeyLocationResolverTest {
         Mockito.verify(mockedGet).setTrustedCertificates(Mockito.any(X509Certificate.class));
         Mockito.verify(mockedGet)
                 .setHostnameVerifier(Mockito.any(AbstractKeyLocationResolver.TrustedHostsHostnameVerifier.class));
+        Mockito.verify(mockedGet).setHttpProxy(Mockito.any(Proxy.class));
         Mockito.verify(mockedHttpsJwks).setSimpleHttpGet(mockedGet);
 
         RsaJsonWebKey jwk = new RsaJsonWebKey(rsaKey);


### PR DESCRIPTION
Fixes #460

`Jose4J`'s `Get` class accepts `Proxy` (no control over the authentication though), so it makes sense to fix this long pending issue  since we have just added the config for TLS certs/hosts too.

Default proxy host is 80, same as it is done for Vertx