### PR TITLE
Use smallrye.jwt.client.tls namespace for configuring TLS

### DIFF
--- a/doc/modules/ROOT/pages/configuration.adoc
+++ b/doc/modules/ROOT/pages/configuration.adoc
@@ -61,9 +61,9 @@ SmallRye JWT supports many properties which can be used to customize the token p
 |smallrye.jwt.decrypt.key.location|none|Config property allows for an external or internal location of Private Decryption Key to be specified. This property is deprecated, use `mp.jwt.decrypt.key.location`.
 |smallrye.jwt.decrypt.algorithm|`RSA_OAEP`|Decryption algorithm.
 |smallrye.jwt.token.decryption.kid|none|Decryption Key identifier. If it is set then the decryption JWK key as well every JWT token must have a matching `kid` header.
-|smallrye.jwt.tls.certificate.path|none|Path to TLS trusted certificate which may need to be configured if the keys have to be fetched over `HTTPS`.
-|smallrye.jwt.tls.trust-all|false|Trust all the hostnames. If the keys have to be fetched over `HTTPS` and this property is set to `true` then all the hostnames are trusted by default.
-|smallrye.jwt.tls.trusted.hosts|none|Set of trusted hostnames. If the keys have to be fetched over `HTTPS` and `smallrye.jwt.tls.trust-all` is set to `false` then then this property can be used to configure the trusted hostnames.
+|smallrye.jwt.client.tls.certificate.path|none|Path to TLS trusted certificate which may need to be configured if the keys have to be fetched over `HTTPS`.
+|smallrye.jwt.client.tls.trust-all|false|Trust all the hostnames. If the keys have to be fetched over `HTTPS` and this property is set to `true` then all the hostnames are trusted by default.
+|smallrye.jwt.client.tls.trusted.hosts|none|Set of trusted hostnames. If the keys have to be fetched over `HTTPS` and `smallrye.jwt.client.tls.trust-all` is set to `false` then then this property can be used to configure the trusted hostnames.
 |smallrye.jwt.http.proxy.host|none|HTTP proxy host.
 |smallrye.jwt.http.proxy.port|80|HTTP proxy port.
 |===

--- a/implementation/jwt-auth/src/main/java/io/smallrye/jwt/config/JWTAuthContextInfoProvider.java
+++ b/implementation/jwt-auth/src/main/java/io/smallrye/jwt/config/JWTAuthContextInfoProvider.java
@@ -414,7 +414,7 @@ public class JWTAuthContextInfoProvider {
      * TLS Trusted Certificate Path.
      */
     @Inject
-    @ConfigProperty(name = "smallrye.jwt.tls.certificate.path")
+    @ConfigProperty(name = "smallrye.jwt.client.tls.certificate.path")
     private Optional<String> tlsCertificatePath;
 
     /**
@@ -422,14 +422,14 @@ public class JWTAuthContextInfoProvider {
      * If this property is set to 'true' then HTTPS HostnameVerifier will trust all the hostnames.
      */
     @Inject
-    @ConfigProperty(name = "smallrye.jwt.tls.trust-all", defaultValue = "false")
+    @ConfigProperty(name = "smallrye.jwt.client.tls.trust-all", defaultValue = "false")
     private boolean tlsTrustAll;
 
     /**
-     * TLS Trusted Hosts. Set this property if `smallrye.jwt.tls.trust-all` property is disabled.
+     * TLS Trusted Hosts. Set this property if `smallrye.jwt.client.tls.trust-all` property is disabled.
      */
     @Inject
-    @ConfigProperty(name = "smallrye.jwt.tls.hosts")
+    @ConfigProperty(name = "smallrye.jwt.client.tls.hosts")
     private Optional<Set<String>> tlsTrustedHosts;
 
     /**


### PR DESCRIPTION
Mike @MikeEdgar has proposed that a `client` qualifier is used in the configuration namespace for TLS, it indeed makes it clearer that they only affect the (http) client (currently when fetching JWKs, to be improved for fetching PEM keys too) 