### PR TITLE
Add smallrye.jwt.client.tls.certificate to support inlined TLS certificates

### DIFF
--- a/doc/modules/ROOT/pages/configuration.adoc
+++ b/doc/modules/ROOT/pages/configuration.adoc
@@ -61,7 +61,8 @@ SmallRye JWT supports many properties which can be used to customize the token p
 |smallrye.jwt.decrypt.key.location|none|Config property allows for an external or internal location of Private Decryption Key to be specified. This property is deprecated, use `mp.jwt.decrypt.key.location`.
 |smallrye.jwt.decrypt.algorithm|`RSA_OAEP`|Decryption algorithm.
 |smallrye.jwt.token.decryption.kid|none|Decryption Key identifier. If it is set then the decryption JWK key as well every JWT token must have a matching `kid` header.
-|smallrye.jwt.client.tls.certificate.path|none|Path to TLS trusted certificate which may need to be configured if the keys have to be fetched over `HTTPS`.
+|smallrye.jwt.client.tls.certificate|none|TLS trusted certificate which may need to be configured if the keys have to be fetched over `HTTPS`. If this property is set then the `smallrye.jwt.client.tls.certificate.path` property will be ignored.
+|smallrye.jwt.client.tls.certificate.path|none|Path to TLS trusted certificate which may need to be configured if the keys have to be fetched over `HTTPS`. This property will be ignored if the `smallrye.jwt.client.tls.certificate` property is set.
 |smallrye.jwt.client.tls.trust-all|false|Trust all the hostnames. If the keys have to be fetched over `HTTPS` and this property is set to `true` then all the hostnames are trusted by default.
 |smallrye.jwt.client.tls.trusted.hosts|none|Set of trusted hostnames. If the keys have to be fetched over `HTTPS` and `smallrye.jwt.client.tls.trust-all` is set to `false` then then this property can be used to configure the trusted hostnames.
 |smallrye.jwt.http.proxy.host|none|HTTP proxy host.

--- a/implementation/jwt-auth/src/main/java/io/smallrye/jwt/auth/principal/AbstractKeyLocationResolver.java
+++ b/implementation/jwt-auth/src/main/java/io/smallrye/jwt/auth/principal/AbstractKeyLocationResolver.java
@@ -104,7 +104,9 @@ public class AbstractKeyLocationResolver {
             } else if (authContextInfo.getTlsTrustedHosts() != null) {
                 httpGet.setHostnameVerifier(new TrustedHostsHostnameVerifier(authContextInfo.getTlsTrustedHosts()));
             }
-            if (authContextInfo.getTlsCertificatePath() != null) {
+            if (authContextInfo.getTlsCertificate() != null) {
+                httpGet.setTrustedCertificates(loadPEMCertificate(authContextInfo.getTlsCertificate()));
+            } else if (authContextInfo.getTlsCertificatePath() != null) {
                 httpGet.setTrustedCertificates(loadPEMCertificate(readKeyContent(authContextInfo.getTlsCertificatePath())));
             }
         }

--- a/implementation/jwt-auth/src/main/java/io/smallrye/jwt/auth/principal/JWTAuthContextInfo.java
+++ b/implementation/jwt-auth/src/main/java/io/smallrye/jwt/auth/principal/JWTAuthContextInfo.java
@@ -64,6 +64,7 @@ public class JWTAuthContextInfo {
     private Set<String> requiredClaims;
     private boolean relaxVerificationKeyValidation = true;
     private boolean verifyCertificateThumbprint;
+    private String tlsCertificate;
     private String tlsCertificatePath;
     private Set<String> tlsTrustedHosts;
     private boolean tlsTrustAll;
@@ -126,6 +127,7 @@ public class JWTAuthContextInfo {
         this.requiredClaims = orig.getRequiredClaims();
         this.relaxVerificationKeyValidation = orig.isRelaxVerificationKeyValidation();
         this.verifyCertificateThumbprint = orig.isVerifyCertificateThumbprint();
+        this.tlsCertificate = orig.getTlsCertificate();
         this.tlsCertificatePath = orig.getTlsCertificatePath();
         this.tlsTrustedHosts = orig.getTlsTrustedHosts();
         this.tlsTrustAll = orig.isTlsTrustAll();
@@ -438,6 +440,14 @@ public class JWTAuthContextInfo {
 
     public void setVerifyCertificateThumbprint(boolean verifyCertificateThumbprint) {
         this.verifyCertificateThumbprint = verifyCertificateThumbprint;
+    }
+
+    public String getTlsCertificate() {
+        return tlsCertificate;
+    }
+
+    public void setTlsCertificate(String tlsCertificate) {
+        this.tlsCertificate = tlsCertificate;
     }
 
     public String getTlsCertificatePath() {

--- a/implementation/jwt-auth/src/main/java/io/smallrye/jwt/config/JWTAuthContextInfoProvider.java
+++ b/implementation/jwt-auth/src/main/java/io/smallrye/jwt/config/JWTAuthContextInfoProvider.java
@@ -128,6 +128,7 @@ public class JWTAuthContextInfoProvider {
         provider.expectedAudience = Optional.empty();
         provider.groupsSeparator = DEFAULT_GROUPS_SEPARATOR;
         provider.requiredClaims = Optional.empty();
+        provider.tlsCertificate = Optional.empty();
         provider.tlsCertificatePath = Optional.empty();
         provider.tlsTrustedHosts = Optional.empty();
         provider.httpProxyHost = Optional.empty();
@@ -411,7 +412,16 @@ public class JWTAuthContextInfoProvider {
     Optional<Set<String>> requiredClaims;
 
     /**
+     * TLS Trusted Certificate.
+     * If this property is set then the 'smallrye.jwt.client.tls.certificate.path' will be ignored.
+     */
+    @Inject
+    @ConfigProperty(name = "smallrye.jwt.client.tls.certificate")
+    private Optional<String> tlsCertificate;
+
+    /**
      * TLS Trusted Certificate Path.
+     * This property will be ignored if the 'smallrye.jwt.client.tls.certificate' is set.
      */
     @Inject
     @ConfigProperty(name = "smallrye.jwt.client.tls.certificate.path")
@@ -529,6 +539,7 @@ public class JWTAuthContextInfoProvider {
         contextInfo.setDefaultSubjectClaim(defaultSubClaim.orElse(null));
         SmallryeJwtUtils.setContextSubPath(contextInfo, subPath);
         contextInfo.setDefaultGroupsClaim(defaultGroupsClaim.orElse(null));
+        contextInfo.setTlsCertificate(tlsCertificate.orElse(null));
         contextInfo.setTlsCertificatePath(tlsCertificatePath.orElse(null));
         contextInfo.setTlsTrustedHosts(tlsTrustedHosts.orElse(null));
         contextInfo.setTlsTrustAll(tlsTrustAll);

--- a/implementation/jwt-auth/src/test/java/io/smallrye/jwt/auth/principal/KeyLocationResolverTest.java
+++ b/implementation/jwt-auth/src/test/java/io/smallrye/jwt/auth/principal/KeyLocationResolverTest.java
@@ -120,9 +120,9 @@ public class KeyLocationResolverTest {
     }
 
     @Test
-    public void testLoadRsaKeyFromHttpsJwksWithCertPathAndTrustAll() throws Exception {
+    public void testLoadRsaKeyFromHttpsJwksWithCertAndTrustAll() throws Exception {
         JWTAuthContextInfo contextInfo = new JWTAuthContextInfo("https://github.com/my_key.jwks", "issuer");
-        contextInfo.setTlsCertificatePath("publicCrt.pem");
+        contextInfo.setTlsCertificate(KeyUtils.readKeyContent("publicCrt.pem"));
         contextInfo.setTlsTrustAll(true);
         contextInfo.setJwksRefreshInterval(10);
 


### PR DESCRIPTION
Fixes #595.

@MikeEdgar Hi Mike, I'm keeping #593 open, in case we'd like to go ahead and support random URL schems via the custom resolvers.

I've updated one of the unit tests to check a new property since there is another test there which checks the certificate path