### PR TITLE
Support for an inlined decryption key

### DIFF
--- a/doc/modules/ROOT/pages/configuration.adoc
+++ b/doc/modules/ROOT/pages/configuration.adoc
@@ -59,6 +59,7 @@ SmallRye JWT supports many properties which can be used to customize the token p
 |smallrye.jwt.verify.aud|none|Comma separated list of the audiences that a token `aud` claim may contain. This property is deprecated. Use `mp.jwt.verify.audiences` instead.
 |smallrye.jwt.required.claims|none|Comma separated list of the claims that a token must contain.
 |smallrye.jwt.decrypt.key.location|none|Config property allows for an external or internal location of Private Decryption Key to be specified. This property is deprecated, use `mp.jwt.decrypt.key.location`.
+|smallrye.jwt.decrypt.key|none|Decryption key supplied as a string.
 |smallrye.jwt.decrypt.algorithm|`RSA_OAEP`|Decryption algorithm.
 |smallrye.jwt.token.decryption.kid|none|Decryption Key identifier. If it is set then the decryption JWK key as well every JWT token must have a matching `kid` header.
 |smallrye.jwt.client.tls.certificate|none|TLS trusted certificate which may need to be configured if the keys have to be fetched over `HTTPS`. If this property is set then the `smallrye.jwt.client.tls.certificate.path` property will be ignored.

--- a/testsuite/basic/src/test/java/io/smallrye/jwt/auth/principal/KeyLocationResolverTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/jwt/auth/principal/KeyLocationResolverTest.java
@@ -187,4 +187,15 @@ public class KeyLocationResolverTest {
         JwtClaims jwt = new DefaultJWTTokenParser().parse(jwtString, contextInfo).getJwtClaims();
         Assert.assertEquals("Alice", jwt.getClaimValueAsString("upn"));
     }
+
+    @Test
+    public void testDecryptToken() throws Exception {
+        String jwtString = Jwt.issuer("https://server.example.com").upn("Alice").jwe().encrypt("publicKey.pem");
+        String decryptionKey = KeyUtils.readKeyContent("privateKey.pem");
+        JWTAuthContextInfoProvider provider = JWTAuthContextInfoProvider.createWithDecryptionKey(decryptionKey,
+                "https://server.example.com");
+        JWTAuthContextInfo contextInfo = provider.getContextInfo();
+        JwtClaims jwt = new DefaultJWTTokenParser().parse(jwtString, contextInfo).getJwtClaims();
+        Assert.assertEquals("Alice", jwt.getClaimValueAsString("upn"));
+    }
 }


### PR DESCRIPTION
This simple PR makes sure the decryption keys can be inlined directly in the configuration the same way it can be done for the verification keys - the motivation is to support a simple extraction of both verification and decryption keys from DB and other sources via `ConfigSource` as one of the users can not verify the inner signed tokens with the keys available in DB. The same was done earlier for `smallrye-jwt-build`. 
Perhaps support for custom KeyLocationResolvers can also be introduced in the next stage, I think Mike tried it earlier but I was concerned about exposing Jose4j specific details