### PR TITLE
Support for reading from default Keystore

### DIFF
--- a/implementation/common/src/main/java/io/smallrye/jwt/util/KeyUtils.java
+++ b/implementation/common/src/main/java/io/smallrye/jwt/util/KeyUtils.java
@@ -285,8 +285,12 @@ public final class KeyUtils {
         KeyStore keyStore = keyStoreProvider.isPresent()
                 ? KeyStore.getInstance(theKeyStoreType, keyStoreProvider.get())
                 : KeyStore.getInstance(theKeyStoreType);
-        try (InputStream is = ResourceUtils.getResourceStream(keyStorePath)) {
-            keyStore.load(is, keyStorePassword.toCharArray());
+        if (keyStorePath != null) {
+            try (InputStream is = ResourceUtils.getResourceStream(keyStorePath)) {
+                keyStore.load(is, keyStorePassword.toCharArray());
+            }
+        } else {
+            keyStore.load(null, keyStorePassword.toCharArray());
         }
         return keyStore;
     }

--- a/implementation/jwt-auth/src/main/java/io/smallrye/jwt/config/JWTAuthContextInfoProvider.java
+++ b/implementation/jwt-auth/src/main/java/io/smallrye/jwt/config/JWTAuthContextInfoProvider.java
@@ -604,6 +604,12 @@ public class JWTAuthContextInfoProvider {
                     }
                 }
             }
+        } else if (isPublicKeyInKeystore()) {
+            try {
+                contextInfo.setPublicVerificationKey(getVerificationKeyFromKeystore(null));
+            } catch (Exception ex) {
+                throw ConfigMessages.msg.readingPublicKeyLocationFailed(ex);
+            }
         }
 
         final String theDecryptionKeyLocation;
@@ -639,6 +645,12 @@ public class JWTAuthContextInfoProvider {
                         throw ConfigMessages.msg.readingDecryptKeyLocationFailed(ex);
                     }
                 }
+            }
+        } else if (isPrivateKeyInKeystore()) {
+            try {
+                contextInfo.setPrivateDecryptionKey(getDecryptionKeyFromKeystore(null));
+            } catch (Exception ex) {
+                throw ConfigMessages.msg.readingDecryptKeyLocationFailed(ex);
             }
         }
 


### PR DESCRIPTION
Minor follow up to the keystore related code: if both the inlined key is null and the key location is null but the keystore alias (and password for the private keys) are set then attempt to load from a default store. It is to support this code:

https://docs.oracle.com/en/java/javase/17/security/pkcs11-reference-guide1.html

Right now one needs to point to the existing keystore location and it is not obvious reading the NSSDB as an InputStream and loading KeyStore from it will work or is sound as this DB may be large

CC @pjgg