### PR TITLE
Allow for non-RSA/EC PrivateKeys when building JWT

### DIFF
--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtSignatureImpl.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtSignatureImpl.java
@@ -215,6 +215,13 @@ class JwtSignatureImpl implements JwtSignature {
             } else if (alg.startsWith("HS")) {
                 return alg;
             }
+        } else if (signingKey instanceof PrivateKey) {
+            // for example, sun.security.pkcs11.P11Key$P11PrivateKey
+            if (alg == null) {
+                return SignatureAlgorithm.RS256.name();
+            } else if (alg.startsWith("RS") || alg.startsWith("PS") || alg.startsWith("ES")) {
+                return alg;
+            }
         }
         throw ImplMessages.msg.unsupportedSignatureAlgorithm(signingKey.getAlgorithm());
     }


### PR DESCRIPTION
This is a minor update to the way the keys are checked when `smallrye-jwt-build` runs on RHEL FIPS. In most cases a generic `P11Key$P11PrivateKey` will be returned which can only be used if `SunPKCS11` provider is installed. At the moment `smallrye-jwt-build` fails early in such cases which is a problem