### PR TITLE
Use a Provider instance instead of a provider string in KeyStore.getInstance

### DIFF
--- a/implementation/common/src/main/java/io/smallrye/jwt/util/KeyUtils.java
+++ b/implementation/common/src/main/java/io/smallrye/jwt/util/KeyUtils.java
@@ -30,8 +30,10 @@ import java.security.KeyPairGenerator;
 import java.security.KeyStore;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
+import java.security.Provider;
 import java.security.PublicKey;
 import java.security.SecureRandom;
+import java.security.Security;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.security.spec.PKCS8EncodedKeySpec;
@@ -282,8 +284,9 @@ public final class KeyUtils {
             Optional<String> keyStoreProvider)
             throws Exception {
         String theKeyStoreType = getKeyStoreType(keyStorePath, keyStoreType);
-        KeyStore keyStore = keyStoreProvider.isPresent()
-                ? KeyStore.getInstance(theKeyStoreType, keyStoreProvider.get())
+        Provider provider = keyStoreProvider.isPresent() ? Security.getProvider(keyStoreProvider.get()) : null;
+        KeyStore keyStore = provider != null
+                ? KeyStore.getInstance(theKeyStoreType, provider)
                 : KeyStore.getInstance(theKeyStoreType);
         if (keyStorePath != null) {
             try (InputStream is = ResourceUtils.getResourceStream(keyStorePath)) {

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtEncryptionImpl.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtEncryptionImpl.java
@@ -85,11 +85,14 @@ class JwtEncryptionImpl implements JwtEncryptionBuilder {
                     }
                 }
             } else {
-                String keyContent = JwtBuildUtils.getConfigProperty(JwtBuildUtils.ENC_KEY_PROPERTY, String.class);
-                if (keyContent != null) {
-                    key = getEncryptionKeyFromKeyContent(keyContent);
-                } else {
-                    throw ImplMessages.msg.encryptionKeyNotConfigured();
+                key = JwtBuildUtils.readPublicKeyFromKeystore(null);
+                if (key == null) {
+                    String keyContent = JwtBuildUtils.getConfigProperty(JwtBuildUtils.ENC_KEY_PROPERTY, String.class);
+                    if (keyContent != null) {
+                        key = getEncryptionKeyFromKeyContent(keyContent);
+                    } else {
+                        throw ImplMessages.msg.encryptionKeyNotConfigured();
+                    }
                 }
             }
             if (key == null) {

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtSignatureImpl.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtSignatureImpl.java
@@ -81,11 +81,14 @@ class JwtSignatureImpl implements JwtSignature {
                         }
                     }
                 } else {
-                    String keyContent = JwtBuildUtils.getConfigProperty(JwtBuildUtils.SIGN_KEY_PROPERTY, String.class);
-                    if (keyContent != null) {
-                        key = getSigningKeyFromKeyContent(keyContent);
-                    } else {
-                        throw ImplMessages.msg.signKeyNotConfigured();
+                    key = JwtBuildUtils.readPrivateKeyFromKeystore(null);
+                    if (key == null) {
+                        String keyContent = JwtBuildUtils.getConfigProperty(JwtBuildUtils.SIGN_KEY_PROPERTY, String.class);
+                        if (keyContent != null) {
+                            key = getSigningKeyFromKeyContent(keyContent);
+                        } else {
+                            throw ImplMessages.msg.signKeyNotConfigured();
+                        }
                     }
                 }
             }


### PR DESCRIPTION
CC @pjgg

This PR updates the code which loads `Keystore` to use a `Provider` instance instead of a string, and also adds as an option to load from a `null` (default) KeyStore to `smallrye-jwt-build` (as a follow up to #606 which missed it and only added this support for the verification part)