### PR TITLE
Add support for ES256K(ECDSA using secp256k1 curve and SHA-256 per RFC8812)

### DIFF
--- a/implementation/common/src/main/java/io/smallrye/jwt/algorithm/SignatureAlgorithm.java
+++ b/implementation/common/src/main/java/io/smallrye/jwt/algorithm/SignatureAlgorithm.java
@@ -12,6 +12,7 @@ public enum SignatureAlgorithm {
     ES256,
     ES384,
     ES512,
+    ES256K,
     HS256,
     HS384,
     HS512,


### PR DESCRIPTION
Fixes #635.

This PR simply adds a new signature algorithm `ES256K` enum value supported with jose4j 0.8.0 and adds a test.
I copied the expansion of the ES256K abbreviation from the jose4j commit made by Brian Campbell