### PR TITLE
Fail loading the keystore if no configured provider is found

### DIFF
--- a/implementation/common/src/main/java/io/smallrye/jwt/util/JWTUtilMessages.java
+++ b/implementation/common/src/main/java/io/smallrye/jwt/util/JWTUtilMessages.java
@@ -3,6 +3,7 @@ package io.smallrye.jwt.util;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.security.InvalidAlgorithmParameterException;
+import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 
 import org.jboss.logging.Messages;
@@ -25,4 +26,7 @@ interface JWTUtilMessages {
 
     @Message(id = 3, value = "Algorithm %s is not a symmetric-key algorithm")
     InvalidAlgorithmParameterException requiresSymmetricAlgo(String algorithmName);
+
+    @Message(id = 4, value = "Keystore provider %s is not found")
+    KeyStoreException keystoreProviderNotFound(String provider);
 }

--- a/implementation/common/src/main/java/io/smallrye/jwt/util/KeyUtils.java
+++ b/implementation/common/src/main/java/io/smallrye/jwt/util/KeyUtils.java
@@ -284,7 +284,13 @@ public final class KeyUtils {
             Optional<String> keyStoreProvider)
             throws Exception {
         String theKeyStoreType = getKeyStoreType(keyStorePath, keyStoreType);
-        Provider provider = keyStoreProvider.isPresent() ? Security.getProvider(keyStoreProvider.get()) : null;
+        Provider provider = null;
+        if (keyStoreProvider.isPresent()) {
+            provider = Security.getProvider(keyStoreProvider.get());
+            if (provider == null) {
+                throw JWTUtilMessages.msg.keystoreProviderNotFound(keyStoreProvider.get());
+            }
+        }
         KeyStore keyStore = provider != null
                 ? KeyStore.getInstance(theKeyStoreType, provider)
                 : KeyStore.getInstance(theKeyStoreType);


### PR DESCRIPTION
Defaulting to a null provider if the configured/requested provider is not found makes it more difficult to debug 
CC @pjgg