### PR TITLE
Add support for EDDSA

### DIFF
--- a/implementation/common/src/main/java/io/smallrye/jwt/algorithm/SignatureAlgorithm.java
+++ b/implementation/common/src/main/java/io/smallrye/jwt/algorithm/SignatureAlgorithm.java
@@ -6,21 +6,28 @@ package io.smallrye.jwt.algorithm;
  * @see <a href="https://tools.ietf.org/html/rfc7518#section-3">https://tools.ietf.org/html/rfc7518#section-3</a>
  */
 public enum SignatureAlgorithm {
-    RS256,
-    RS384,
-    RS512,
-    ES256,
-    ES384,
-    ES512,
-    HS256,
-    HS384,
-    HS512,
-    PS256,
-    PS384,
-    PS512;
+    RS256("RS256"),
+    RS384("RS384"),
+    RS512("RS512"),
+    ES256("ES256"),
+    ES384("ES384"),
+    ES512("ES512"),
+    EDDSA("EdDSA"),
+    HS256("HS256"),
+    HS384("HS384"),
+    HS512("HS512"),
+    PS256("PS256"),
+    PS384("PS384"),
+    PS512("PS512");
+
+    private String algorithmName;
+
+    private SignatureAlgorithm(String algorithmName) {
+        this.algorithmName = algorithmName;
+    }
 
     public String getAlgorithm() {
-        return this.name();
+        return algorithmName;
     }
 
     public static SignatureAlgorithm fromAlgorithm(String algorithmName) {

--- a/implementation/common/src/main/java/io/smallrye/jwt/util/KeyUtils.java
+++ b/implementation/common/src/main/java/io/smallrye/jwt/util/KeyUtils.java
@@ -562,4 +562,13 @@ public final class KeyUtils {
         }
         return null;
     }
+
+    public static boolean isSupportedKey(Key key, String keyInterfaceName) {
+        for (Class<?> intf : key.getClass().getInterfaces()) {
+            if (keyInterfaceName.equals(intf.getName())) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/implementation/jwt-auth/src/main/java/io/smallrye/jwt/auth/principal/DefaultJWTParser.java
+++ b/implementation/jwt-auth/src/main/java/io/smallrye/jwt/auth/principal/DefaultJWTParser.java
@@ -16,6 +16,7 @@
  */
 package io.smallrye.jwt.auth.principal;
 
+import java.security.Key;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.interfaces.ECPrivateKey;
@@ -37,6 +38,9 @@ import io.smallrye.jwt.util.KeyUtils;
  */
 @ApplicationScoped
 public class DefaultJWTParser implements JWTParser {
+
+    private static final String ED_EC_PUBLIC_KEY_INTERFACE = "java.security.interfaces.EdECPublicKey";
+    private static final String XEC_PRIVATE_KEY_INTERFACE = "java.security.interfaces.XECPrivateKey";
 
     @Inject
     private JWTAuthContextInfo authContextInfo;
@@ -87,6 +91,8 @@ public class DefaultJWTParser implements JWTParser {
         newAuthContextInfo.setPublicVerificationKey(key);
         if (key instanceof ECPublicKey) {
             setSignatureAlgorithmIfNeeded(newAuthContextInfo, "ES", SignatureAlgorithm.ES256);
+        } else if (isEdECPublicKey(key)) {
+            setSignatureAlgorithmIfNeeded(newAuthContextInfo, "EdDSA", SignatureAlgorithm.EDDSA);
         } else {
             setSignatureAlgorithmIfNeeded(newAuthContextInfo, "RS", SignatureAlgorithm.RS256);
         }
@@ -110,7 +116,7 @@ public class DefaultJWTParser implements JWTParser {
     public JsonWebToken decrypt(String bearerToken, PrivateKey key) throws ParseException {
         JWTAuthContextInfo newAuthContextInfo = copyAuthContextInfo();
         newAuthContextInfo.setPrivateDecryptionKey(key);
-        if (key instanceof ECPrivateKey) {
+        if (key instanceof ECPrivateKey || isXecPrivateKey(key)) {
             setKeyEncryptionAlgorithmIfNeeded(newAuthContextInfo, "EC", KeyEncryptionAlgorithm.ECDH_ES_A256KW);
         } else {
             setKeyEncryptionAlgorithmIfNeeded(newAuthContextInfo, "RS", KeyEncryptionAlgorithm.RSA_OAEP);
@@ -156,5 +162,13 @@ public class DefaultJWTParser implements JWTParser {
         if (algo == null || !algo.getAlgorithm().startsWith(algoStart)) {
             newAuthContextInfo.setKeyEncryptionAlgorithm(newAlgo);
         }
+    }
+
+    private static boolean isEdECPublicKey(Key verificationKey) {
+        return KeyUtils.isSupportedKey(verificationKey, ED_EC_PUBLIC_KEY_INTERFACE);
+    }
+
+    private static boolean isXecPrivateKey(Key encKey) {
+        return KeyUtils.isSupportedKey(encKey, XEC_PRIVATE_KEY_INTERFACE);
     }
 }

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/ImplMessages.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/ImplMessages.java
@@ -104,4 +104,10 @@ interface ImplMessages {
 
     @Message(id = 5031, value = "Encryption key can not be read from the keystore")
     IllegalArgumentException encryptionKeyCanNotBeReadFromKeystore(@Cause Throwable throwable);
+
+    @Message(id = 5032, value = "Signing key is null")
+    NullPointerException signingKeyIsNull();
+
+    @Message(id = 5033, value = "Encryption key is null")
+    NullPointerException encryptionKeyIsNull();
 }

--- a/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtEncryptTest.java
+++ b/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtEncryptTest.java
@@ -18,7 +18,6 @@ package io.smallrye.jwt.build;
 
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
@@ -42,6 +41,8 @@ import org.jose4j.jwe.JsonWebEncryption;
 import org.jose4j.jwk.EcJwkGenerator;
 import org.jose4j.jwk.EllipticCurveJsonWebKey;
 import org.jose4j.jwk.JsonWebKey;
+import org.jose4j.jwk.OctetKeyPairJsonWebKey;
+import org.jose4j.jwk.OkpJwkGenerator;
 import org.jose4j.jwt.JwtClaims;
 import org.jose4j.keys.EllipticCurves;
 import org.jose4j.keys.PbkdfKey;
@@ -271,6 +272,44 @@ public class JwtEncryptTest {
 
         JwtClaims claims = JwtClaims.parse(jwe.getPlaintextString());
         checkJwtClaims(claims);
+    }
+
+    @Test
+    public void testEncryptWithEcKeyX25519() throws Exception {
+        if (Runtime.version().version().get(0) >= 17) {
+            OctetKeyPairJsonWebKey jwk = OkpJwkGenerator.generateJwk(OctetKeyPairJsonWebKey.SUBTYPE_X25519);
+            String jweCompact = Jwt.claims()
+                    .claim("customClaim", "custom-value")
+                    .jwe()
+                    .keyId("key-enc-key-id")
+                    .encrypt(jwk.getPublicKey());
+
+            checkJweHeaders(jweCompact, "ECDH-ES+A256KW", 4);
+
+            JsonWebEncryption jwe = getJsonWebEncryption(jweCompact, jwk.getPrivateKey());
+
+            JwtClaims claims = JwtClaims.parse(jwe.getPlaintextString());
+            checkJwtClaims(claims);
+        }
+    }
+
+    @Test
+    public void testEncryptWithEcKeyX448() throws Exception {
+        if (Runtime.version().version().get(0) >= 17) {
+            OctetKeyPairJsonWebKey jwk = OkpJwkGenerator.generateJwk(OctetKeyPairJsonWebKey.SUBTYPE_X448);
+            String jweCompact = Jwt.claims()
+                    .claim("customClaim", "custom-value")
+                    .jwe()
+                    .keyId("key-enc-key-id")
+                    .encrypt(jwk.getPublicKey());
+
+            checkJweHeaders(jweCompact, "ECDH-ES+A256KW", 4);
+
+            JsonWebEncryption jwe = getJsonWebEncryption(jweCompact, jwk.getPrivateKey());
+
+            JwtClaims claims = JwtClaims.parse(jwe.getPlaintextString());
+            checkJwtClaims(claims);
+        }
     }
 
     @Test

--- a/implementation/jwt-build/src/test/resources/edEcPrivateKey.jwk
+++ b/implementation/jwt-build/src/test/resources/edEcPrivateKey.jwk
@@ -1,0 +1,6 @@
+{
+  "kty":"OKP",
+  "crv":"Ed25519",
+  "d":"nWGxne_9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A",
+  "x":"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"
+}

--- a/implementation/jwt-build/src/test/resources/edEcPublicKey.jwk
+++ b/implementation/jwt-build/src/test/resources/edEcPublicKey.jwk
@@ -1,0 +1,5 @@
+{
+  "kty":"OKP",
+  "crv":"Ed25519",
+  "x":"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"
+}

--- a/testsuite/basic/src/test/resources/edEcPrivateKey.jwk
+++ b/testsuite/basic/src/test/resources/edEcPrivateKey.jwk
@@ -1,0 +1,6 @@
+{
+  "kty":"OKP",
+  "crv":"Ed25519",
+  "d":"nWGxne_9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A",
+  "x":"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"
+}

--- a/testsuite/basic/src/test/resources/edEcPublicKey.jwk
+++ b/testsuite/basic/src/test/resources/edEcPublicKey.jwk
@@ -1,0 +1,5 @@
+{
+  "kty":"OKP",
+  "crv":"Ed25519",
+  "x":"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"
+}


### PR DESCRIPTION
This PR adds a support to the EDDSA family of signature and encryption algorithms now also supported at the jose4j level.
EDDSA and its Ed25519 variant is considered to be one of the most secure and compact modern signature algorithms.

Good overview is for ex here:
https://cryptobook.nakov.com/digital-signatures/eddsa-and-ed25519

FYI, GitHub now uses Ed25519 with SSH keys: https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#generating-a-new-ssh-key

I'd like to release smallrye-jwt once this PR is merged