### PR TITLE
Allow removing claims when bulding JWT

### DIFF
--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/JwtClaimsBuilder.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/JwtClaimsBuilder.java
@@ -205,6 +205,14 @@ public interface JwtClaimsBuilder extends JwtSignature {
     JwtClaimsBuilder claim(String name, Object value);
 
     /**
+     * Remove a claim.
+     *
+     * @param name the claim name
+     * @return JwtClaimsBuilder
+     */
+    JwtClaimsBuilder remove(String name);
+
+    /**
      * Set JsonWebSignature headers and sign the claims by moving to {@link JwtSignatureBuilder}
      *
      * @return JwtSignatureBuilder

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtClaimsBuilderImpl.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtClaimsBuilderImpl.java
@@ -378,4 +378,10 @@ class JwtClaimsBuilderImpl extends JwtSignatureImpl implements JwtClaimsBuilder,
         }
     }
 
+    @Override
+    public JwtClaimsBuilder remove(String name) {
+        claims.unsetClaim(name);
+        return this;
+    }
+
 }


### PR DESCRIPTION
Fixes #419.

I've been planning it for a while, removing a claim can be handy when the builder was initialized from more than one claim, example, from the injected `JsonWebToken`, and not all of the original claims have to make it into a new token, for example:
```
@Inject
JsonWebToken inJwt;

String outJwt = Jwt.claims(inJwt).remove("phone").sign();
```

etc.

I'd like to release `4.3.0` once this PR is reviewed, merged