### PR TITLE
Support for the scope claim in JWT Build API

### DIFF
--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/Jwt.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/Jwt.java
@@ -188,6 +188,26 @@ public final class Jwt {
     }
 
     /**
+     * Creates a new instance of {@link JwtClaimsBuilder} with a specified 'scope' claim.
+     *
+     * @param scope the scope
+     * @return {@link JwtClaimsBuilder}
+     */
+    public static JwtClaimsBuilder scope(String scope) {
+        return claims().scope(scope);
+    }
+
+    /**
+     * Creates a new instance of {@link JwtClaimsBuilder} with a specified 'scope' claim.
+     *
+     * @param scopes the scopes
+     * @return {@link JwtClaimsBuilder}
+     */
+    public static JwtClaimsBuilder scope(Set<String> scopes) {
+        return claims().scope(scopes);
+    }
+
+    /**
      * Creates a new instance of {@link JwtClaimsBuilder} with a specified 'audience' claim.
      *
      * @param audience the audience

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/JwtClaimsBuilder.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/JwtClaimsBuilder.java
@@ -132,7 +132,9 @@ public interface JwtClaimsBuilder extends JwtSignature {
      * @param group the groups
      * @return JwtClaimsBuilder
      */
-    JwtClaimsBuilder groups(String group);
+    default JwtClaimsBuilder groups(String group) {
+        return groups(Set.of(group));
+    }
 
     /**
      * Set a multiple value 'groups' claim
@@ -143,6 +145,25 @@ public interface JwtClaimsBuilder extends JwtSignature {
     JwtClaimsBuilder groups(Set<String> groups);
 
     /**
+     * Set a 'scope' claim value
+     *
+     * @param scope the scope
+     * @return JwtClaimsBuilder
+     */
+    default JwtClaimsBuilder scope(String scope) {
+        return scope(Set.of(scope));
+    }
+
+    /**
+     * Set a multiple value 'scope' claim whose value will be represented as a String
+     * where each scope value is separated by the " " space character.
+     *
+     * @param scopes the scopes
+     * @return JwtClaimsBuilder
+     */
+    JwtClaimsBuilder scope(Set<String> scopes);
+
+    /**
      * Set a single value audience 'aud' claim
      *
      * @param audience the audience
@@ -151,7 +172,7 @@ public interface JwtClaimsBuilder extends JwtSignature {
     JwtClaimsBuilder audience(String audience);
 
     /**
-     * Set a multiple value audience 'aud' claim
+     * Set a multiple value audience 'aud' claim whose value will be represented as a JSON array
      *
      * @param audiences the audiences
      * @return JwtClaimsBuilder

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtClaimsBuilderImpl.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtClaimsBuilderImpl.java
@@ -35,6 +35,7 @@ import io.smallrye.jwt.build.JwtSignatureException;
  */
 class JwtClaimsBuilderImpl extends JwtSignatureImpl implements JwtClaimsBuilder, JwtSignatureBuilder {
 
+    private static final String SCOPE_CLAIM = "scope";
     private static final StringVerifier STRING_VERIFIER = new StringVerifier();
     private static final InstantVerifier INSTANT_VERIFIER = new InstantVerifier();
     private static final StringCollectionVerifier STRING_COLLECTION_VERIFIER = new StringCollectionVerifier();
@@ -167,16 +168,14 @@ class JwtClaimsBuilderImpl extends JwtSignatureImpl implements JwtClaimsBuilder,
      * {@inheritDoc}
      */
     @Override
-    public JwtClaimsBuilder groups(String group) {
-        return groups(Collections.singleton(group));
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public JwtClaimsBuilder groups(Set<String> groups) {
         claims.setClaim(Claims.groups.name(), groups.stream().collect(Collectors.toList()));
+        return this;
+    }
+
+    @Override
+    public JwtClaimsBuilder scope(Set<String> scopes) {
+        claims.setClaim(SCOPE_CLAIM, scopes.stream().collect(Collectors.joining(" ")));
         return this;
     }
 
@@ -383,5 +382,4 @@ class JwtClaimsBuilderImpl extends JwtSignatureImpl implements JwtClaimsBuilder,
         claims.unsetClaim(name);
         return this;
     }
-
 }

--- a/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtSignTest.java
+++ b/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtSignTest.java
@@ -489,6 +489,7 @@ class JwtSignTest {
     @Test
     void signClaimsAllTypes() throws Exception {
         String jwt = Jwt.claims()
+                .scope(Set.of("read:data", "write:data"))
                 .claim("stringClaim", "string")
                 .claim("booleanClaim", true)
                 .claim("numberClaim", 3)
@@ -502,8 +503,11 @@ class JwtSignTest {
         JsonWebSignature jws = getVerifiedJws(jwt);
         JwtClaims claims = JwtClaims.parse(jws.getPayload());
 
-        assertEquals(11, claims.getClaimsMap().size());
+        assertEquals(12, claims.getClaimsMap().size());
         checkDefaultClaimsAndHeaders(getJwsHeaders(jwt, 2), claims);
+
+        String scope = claims.getStringClaimValue("scope");
+        assertTrue("read:data write:data".equals(scope) || "write:data read:data".equals(scope));
 
         assertEquals("string", claims.getClaimValue("stringClaim"));
         assertTrue((Boolean) claims.getClaimValue("booleanClaim"));


### PR DESCRIPTION
Fixes #725 

This PR provides a typed support for a `scope` claim whose origins are in OAuth2 but is used by OIDC providers.

For example, instead of writing a code like this:

https://github.com/quarkusio/quarkus/blob/main/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/ServicePublicKeyTestCase.java#L28

I'd like to write

`Jwt.scope("read:data")`, etc.

This PR also simplifies a bit the implementation of `groups` setters