### PR TITLE
Support parsing already verified tokens

### DIFF
--- a/implementation/jwt-auth/src/main/java/io/smallrye/jwt/auth/principal/JWTParser.java
+++ b/implementation/jwt-auth/src/main/java/io/smallrye/jwt/auth/principal/JWTParser.java
@@ -120,4 +120,9 @@ public interface JWTParser {
      */
     public JsonWebToken decrypt(final String token, String secret) throws ParseException;
 
+    /**
+     * Parse an already verified signed JWT token.
+     * Use this method only if the token has been verified by the secure gateway or other systems.
+     */
+    public JsonWebToken parseOnly(final String token) throws ParseException;
 }

--- a/implementation/jwt-auth/src/main/java/io/smallrye/jwt/auth/principal/PrincipalMessages.java
+++ b/implementation/jwt-auth/src/main/java/io/smallrye/jwt/auth/principal/PrincipalMessages.java
@@ -84,4 +84,6 @@ interface PrincipalMessages {
     @Message(id = 7021, value = "JWK set does not contain provided token 'kid'")
     UnmatchedTokenKidException unmatchedTokenKidException();
 
+    @Message(id = 7022, value = "Failed to parse a token")
+    ParseException failedToParseToken(@Cause Throwable throwable);
 }

--- a/testsuite/basic/src/test/java/io/smallrye/jwt/auth/principal/DefaultJWTParserTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/jwt/auth/principal/DefaultJWTParserTest.java
@@ -29,6 +29,13 @@ import io.smallrye.jwt.util.ResourceUtils;
 
 class DefaultJWTParserTest {
     @Test
+    void parseOnly() throws Exception {
+        String jwtString = Jwt.upn("jdoe@example.com").sign(KeyUtils.readPrivateKey("/privateKey.pem"));
+        JsonWebToken jwt = new DefaultJWTParser().parseOnly(jwtString);
+        assertEquals("jdoe@example.com", jwt.getName());
+    }
+
+    @Test
     void parseWithConfiguredPublicKey() throws Exception {
         String jwtString = Jwt.upn("jdoe@example.com").issuer("https://server.example.com")
                 .sign(KeyUtils.readPrivateKey("/privateKey.pem"));


### PR DESCRIPTION
I've had 2 user requests over may be the last 6 months where users would like to use `JsonWebToken` API but without doing another round of verification (ex in various AWS setups) but also without registering custom factories which can be used such purposes.

A simple `parseOnly` method is added to `JwtParser` to support such cases