### PR TITLE
Release SmallRye JWT 4.4.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: SmallRye JWT
 release:
-  current-version: 4.3.1
-  next-version: 4.3.2-SNAPSHOT
+  current-version: 4.4.0
+  next-version: 4.4.1-SNAPSHOT


### PR DESCRIPTION
Proposing a version bump from 4.3.1 to 4.4.0 as 2 public interfaces got updated with new methods