### PR TITLE
Improve handling of file system resources

### DIFF
--- a/implementation/common/src/main/java/io/smallrye/jwt/util/JWTUtilLogging.java
+++ b/implementation/common/src/main/java/io/smallrye/jwt/util/JWTUtilLogging.java
@@ -38,4 +38,8 @@ interface JWTUtilLogging extends BasicLogger {
     @LogMessage(level = Logger.Level.DEBUG)
     @Message(id = 1009, value = "Failed to parse the JWK JSON representation")
     void parsingJwksFailed();
+
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 1010, value = "File %s is not found")
+    void fileIsNotFound(String fileLocation);
 }

--- a/implementation/common/src/main/java/io/smallrye/jwt/util/KeyUtils.java
+++ b/implementation/common/src/main/java/io/smallrye/jwt/util/KeyUtils.java
@@ -296,8 +296,11 @@ public final class KeyUtils {
                 ? KeyStore.getInstance(theKeyStoreType, provider)
                 : KeyStore.getInstance(theKeyStoreType);
         if (keyStorePath != null) {
-            try (InputStream is = ResourceUtils.getResourceStream(keyStorePath)) {
-                keyStore.load(is, keyStorePassword.toCharArray());
+            InputStream is = ResourceUtils.getResourceStream(keyStorePath.trim());
+            if (is != null) {
+                try (InputStream keyStream = is) {
+                    keyStore.load(keyStream, keyStorePassword.toCharArray());
+                }
             }
         } else {
             keyStore.load(null, keyStorePassword.toCharArray());

--- a/implementation/common/src/main/java/io/smallrye/jwt/util/ResourceUtils.java
+++ b/implementation/common/src/main/java/io/smallrye/jwt/util/ResourceUtils.java
@@ -104,6 +104,7 @@ public final class ResourceUtils {
         try {
             return new FileInputStream(publicKeyLocation);
         } catch (FileNotFoundException e) {
+            JWTUtilLogging.log.fileIsNotFound(publicKeyLocation);
             return null;
         }
     }

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtEncryptionImpl.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtEncryptionImpl.java
@@ -81,8 +81,11 @@ class JwtEncryptionImpl implements JwtEncryptionBuilder {
             if (keyLocation != null) {
                 key = JwtBuildUtils.readPublicKeyFromKeystore(keyLocation.trim());
                 if (key == null) {
-                    try (InputStream keyStream = ResourceUtils.getResourceStream(keyLocation.trim())) {
-                        key = getEncryptionKeyFromKeyContent(new String(ResourceUtils.readBytes(keyStream)));
+                    InputStream is = ResourceUtils.getResourceStream(keyLocation.trim());
+                    if (is != null) {
+                        try (InputStream keyStream = is) {
+                            key = getEncryptionKeyFromKeyContent(new String(ResourceUtils.readBytes(keyStream)));
+                        }
                     }
                 }
             } else {

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtSignatureImpl.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtSignatureImpl.java
@@ -78,8 +78,11 @@ class JwtSignatureImpl implements JwtSignature {
                 if (keyLocation != null) {
                     key = JwtBuildUtils.readPrivateKeyFromKeystore(keyLocation.trim());
                     if (key == null) {
-                        try (InputStream keyStream = ResourceUtils.getResourceStream(keyLocation.trim())) {
-                            key = getSigningKeyFromKeyContent(new String(ResourceUtils.readBytes(keyStream)));
+                        InputStream is = ResourceUtils.getResourceStream(keyLocation.trim());
+                        if (is != null) {
+                            try (InputStream keyStream = is) {
+                                key = getSigningKeyFromKeyContent(new String(ResourceUtils.readBytes(keyStream)));
+                            }
                         }
                     }
                 } else {

--- a/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtSignPS256Test.java
+++ b/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtSignPS256Test.java
@@ -18,6 +18,7 @@ package io.smallrye.jwt.build;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.io.File;
 import java.security.Security;
 
 import org.jose4j.jws.JsonWebSignature;
@@ -56,10 +57,12 @@ class JwtSignPS256Test {
 
     @Test
     void signClaimsPS256() throws Exception {
+        String path = "src/test/resources/privateKey.pem";
+        File file = new File(path);
         String jwt = Jwt.claims()
                 .claim("customClaim", "custom-value")
                 .jws().algorithm(SignatureAlgorithm.PS256)
-                .sign("/privateKey.pem");
+                .sign("file:" + file.getAbsolutePath());
 
         JsonWebSignature jws = JwtSignTest.getVerifiedJws(jwt, KeyUtils.readPublicKey("/publicKey.pem"));
         JwtClaims claims = JwtClaims.parse(jws.getPayload());


### PR DESCRIPTION
Fixes #746

This PR logs when the file system resource is not found, and prevents NPEs in a few places where a null stream can be consumed, exceptions will be thrown in those places eventually too.

I'll release 4.4.0 once this PR is merged