### PR TITLE
Instant claims may be non-integer values

### DIFF
--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtClaimsBuilderImpl.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtClaimsBuilderImpl.java
@@ -53,6 +53,7 @@ class JwtClaimsBuilderImpl extends JwtSignatureImpl implements JwtClaimsBuilder,
         REGISTERED_CLAIM_VERIFIERS.put(Claims.upn.name(), STRING_VERIFIER);
         REGISTERED_CLAIM_VERIFIERS.put(Claims.preferred_username.name(), STRING_VERIFIER);
         REGISTERED_CLAIM_VERIFIERS.put(Claims.iat.name(), INSTANT_VERIFIER);
+        REGISTERED_CLAIM_VERIFIERS.put(Claims.auth_time.name(), INSTANT_VERIFIER);
         REGISTERED_CLAIM_VERIFIERS.put(Claims.exp.name(), INSTANT_VERIFIER);
         REGISTERED_CLAIM_VERIFIERS.put(Claims.aud.name(), STRING_COLLECTION_VERIFIER);
         REGISTERED_CLAIM_VERIFIERS.put(Claims.groups.name(), STRING_COLLECTION_VERIFIER);
@@ -380,6 +381,10 @@ class JwtClaimsBuilderImpl extends JwtSignatureImpl implements JwtClaimsBuilder,
         public Object verify(String name, Object value) {
             if (value instanceof Long) {
                 return value;
+            }
+            // If a Number is passed, it must be converted to long
+            if (value instanceof Number) {
+                return ((Number) value).longValue();
             }
             throw new IllegalArgumentException(String.format("'%s' claim value must be long", name));
         }

--- a/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtClaimTypeVerifierTest.java
+++ b/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtClaimTypeVerifierTest.java
@@ -62,13 +62,24 @@ class JwtClaimTypeVerifierTest {
     void iat() {
         Jwt.claim(Claims.iat, Instant.now().getEpochSecond());
         Jwt.claim(Claims.iat, Instant.now());
+        Jwt.claim(Claims.iat, 1705105035.125D);
         assertThrows(IllegalArgumentException.class, () -> Jwt.claim(Claims.iat, "1"), "IllegalArgumentException is expected");
+    }
+
+    @Test
+    void auth_time() {
+        Jwt.claim(Claims.auth_time, Instant.now().getEpochSecond());
+        Jwt.claim(Claims.auth_time, Instant.now());
+        Jwt.claim(Claims.auth_time, 1704986861.532D);
+        assertThrows(IllegalArgumentException.class, () -> Jwt.claim(Claims.auth_time, "1"),
+                "IllegalArgumentException is expected");
     }
 
     @Test
     void exp() {
         Jwt.claim(Claims.exp, Instant.now().getEpochSecond());
         Jwt.claim(Claims.exp, Instant.now());
+        Jwt.claim(Claims.exp, 1712762861.532D);
         assertThrows(IllegalArgumentException.class, () -> Jwt.claim(Claims.exp, "1"), "IllegalArgumentException is expected");
     }
 


### PR DESCRIPTION
Spec states the `exp` claim to be:

```
A JSON numeric value representing the number of seconds from 1970-01-01T00:00:00Z UTC until the specified UTC date/time,
ignoring leap seconds. This is equivalent to the IEEE Std 1003.1, 2013 Edition [POSIX.1] definition "Seconds Since the Epoch", in
which each day is accounted for by exactly 86400 seconds, other than that non-integer values can be represented. See RFC 3339
[RFC3339] for details regarding date/times in general and UTC in particular.
```