### PR TITLE
Parse time claims as Number and convert to Long.

### DIFF
--- a/implementation/jwt-auth/src/main/java/io/smallrye/jwt/auth/principal/DefaultJWTCallerPrincipal.java
+++ b/implementation/jwt-auth/src/main/java/io/smallrye/jwt/auth/principal/DefaultJWTCallerPrincipal.java
@@ -107,7 +107,10 @@ public class DefaultJWTCallerPrincipal extends JWTCallerPrincipal {
             case nbf:
             case updated_at:
                 try {
-                    claim = claimsSet.getClaimValue(claimType.name(), Long.class);
+                    Number numberClaim = claimsSet.getClaimValue(claimType.name(), Number.class);
+                    if (numberClaim != null) {
+                        claim = numberClaim.longValue();
+                    }
                     if (claim == null) {
                         claim = 0L;
                     }

--- a/testsuite/basic/src/test/java/io/smallrye/jwt/auth/principal/DefaultJWTCallerPrincipalTest.java
+++ b/testsuite/basic/src/test/java/io/smallrye/jwt/auth/principal/DefaultJWTCallerPrincipalTest.java
@@ -9,6 +9,7 @@ import java.util.Set;
 
 import org.eclipse.microprofile.jwt.Claims;
 import org.eclipse.microprofile.jwt.tck.util.TokenUtils;
+import org.jose4j.jwt.JwtClaims;
 import org.jose4j.jwt.consumer.JwtContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -56,5 +57,25 @@ class DefaultJWTCallerPrincipalTest {
         assertNotNull(audience);
         assertEquals(1, audience.size());
         assertArrayEquals(new String[] { TCK_TOKEN1_AUD }, audience.toArray(new String[0]));
+    }
+
+    @Test
+    void claimsWithDecimalValues() {
+        Double exp = 1311281970.5;
+        Double iat = 1311280970.5;
+
+        final JwtClaims claims = context.getJwtClaims();
+        claims.setClaim(Claims.exp.name(), exp);
+        claims.setClaim(Claims.iat.name(), iat);
+        DefaultJWTCallerPrincipal principal = new DefaultJWTCallerPrincipal(claims);
+
+        Long expClaim = principal.getExpirationTime();
+        Long iatClaim = principal.getIssuedAtTime();
+
+        assertNotNull(expClaim);
+        assertNotNull(iatClaim);
+
+        assertEquals(exp.longValue(), expClaim);
+        assertEquals(iat.longValue(), iatClaim);
     }
 }


### PR DESCRIPTION
When integrating with Jetbrains Hub as an OpenID provider, found that it returns the time fields in the JWT as seconds since epoch and miliseconds in the decimal part.

Example:

    "exp": 1712762861.532,
    "iat": 1705105035.125,
    "auth_time": 1704986861.532,

This was causing a `org.jose4j.jwt.MalformedClaimException` to be thrown as `Double` can't be cast to `Long` at first sight this seems a bug in the OpenID provider, but the spec is vague about the definition.

    A JSON numeric value representing the number of seconds from
    1970-01-01T00:00:00Z UTC until the specified UTC date/time,
    ignoring leap seconds. This is equivalent to the IEEE Std 1003.1,
    2013 Edition [POSIX.1] definition "Seconds Since the Epoch", in
    which each day is accounted for by exactly 86400 seconds, other
    than that non-integer values can be represented. See RFC 3339
    [RFC3339] for details regarding date/times in general and UTC in
    particular.

There is no specific mention that the value has to be `Long`.

This PR aims to prevent such cases by getting the `Claim` as `Number` and then returning it as a `Long`


Further information can be found on the Zulip thread: https://quarkusio.zulipchat.com/#narrow/stream/187030-users/topic/The.20value.20of.20the.20'exp'.20claim.20is.20not.20the.20expected.20type

Tests not added yet as I'm unsure how I can write such test.