### PR TITLE
Support for the 'jwk' JWT header

### DIFF
--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/Jwt.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/Jwt.java
@@ -1,5 +1,6 @@
 package io.smallrye.jwt.build;
 
+import java.security.PublicKey;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.Map;
@@ -102,12 +103,16 @@ public final class Jwt {
     /**
      * Creates a new instance of {@link JwtClaimsBuilder} with a specified claim.
      *
-     * Simple claim value are converted to {@link String} unless it is an instance of {@link Boolean}, {@link Number} or
-     * {@link Instant}. {@link Instant} values have their number of seconds from the epoch converted to long.
-     *
+     * Simple claim value are converted to {@link String} unless it is an instance of {@link Boolean}, {@link Number},
+     * {@link Instant} or {@link PublicKey}.
+     * <p/>
+     * {@link Instant} values have their number of seconds from the epoch converted to long.
+     * <p/>
+     * {@link PublicKey} values are converted to JSON Web Key (JWK) representations.
+     * <p/>
      * Array claims can be set as {@link Collection} or {@link JsonArray}, complex claims can be set as {@link Map} or
      * {@link JsonObject}. The members of the array claims can be complex claims.
-     *
+     * <p/>
      * Types of the claims directly supported by this builder are enforced.
      * The 'iss' (issuer), 'sub' (subject), 'upn', 'preferred_username' and 'jti' (token identifier) claims must be of
      * {@link String} type.
@@ -126,12 +131,16 @@ public final class Jwt {
     /**
      * Creates a new instance of {@link JwtClaimsBuilder} with a specified claim.
      *
-     * Simple claim value are converted to {@link String} unless it is an instance of {@link Boolean}, {@link Number} or
-     * {@link Instant}. {@link Instant} values have their number of seconds from the epoch converted to long.
-     *
+     * Simple claim value are converted to {@link String} unless it is an instance of {@link Boolean}, {@link Number},
+     * {@link Instant} or {@linkplain PublicKey}.
+     * <p/>
+     * {@link Instant} values have their number of seconds from the epoch converted to long.
+     * <p/>
+     * {@link PublicKey} values are converted to JSON Web Key (JWK) representations.
+     * <p/>
      * Array claims can be set as {@link Collection} or {@link JsonArray}, complex claims can be set as {@link Map} or
      * {@link JsonObject}. The members of the array claims can be complex claims.
-     *
+     * <p/>
      * Types of the claims directly supported by this builder are enforced.
      * The 'iss' (issuer), 'sub' (subject), 'upn', 'preferred_username' and 'jti' (token identifier) claims must be of
      * {@link String} type.

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/JwtClaimsBuilder.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/JwtClaimsBuilder.java
@@ -1,5 +1,6 @@
 package io.smallrye.jwt.build;
 
+import java.security.PublicKey;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
@@ -182,12 +183,16 @@ public interface JwtClaimsBuilder extends JwtSignature {
     /**
      * Set a claim.
      *
-     * Simple claim value are converted to {@link String} unless it is an instance of {@link Boolean}, {@link Number} or
-     * {@link Instant}. {@link Instant} values have their number of seconds from the epoch converted to long.
-     *
-     * Array claims can be set as {@link Collection} or {@link JsonArray} and complex claims can be set as {@link Map} or
+     * Simple claim value are converted to {@link String} unless it is an instance of {@link Boolean}, {@link Number},
+     * {@link Instant} or {@link PublicKey}.
+     * <p/>
+     * {@link Instant} values have their number of seconds from the epoch converted to long.
+     * <p/>
+     * {@link PublicKey} values are converted to JSON Web Key (JWK) representations.
+     * <p/>
+     * Array claims can be set as {@link Collection} or {@link JsonArray}, complex claims can be set as {@link Map} or
      * {@link JsonObject}. The members of the array claims can be complex claims.
-     *
+     * <p/>
      * Types of claims directly supported by this builder are enforced.
      * The 'iss' (issuer), 'sub' (subject), 'upn', 'preferred_username' and 'jti' (token identifier) claims must be of
      * {@link String} type.
@@ -206,12 +211,16 @@ public interface JwtClaimsBuilder extends JwtSignature {
     /**
      * Set a claim.
      *
-     * Simple claim value are converted to {@link String} unless it is an instance of {@link Boolean}, {@link Number} or
-     * {@link Instant}. {@link Instant} values have their number of seconds from the epoch converted to long.
-     *
+     * Simple claim value are converted to {@link String} unless it is an instance of {@link Boolean}, {@link Number},
+     * {@link Instant} or {@link PublicKey}.
+     * <p/>
+     * {@link Instant} values have their number of seconds from the epoch converted to long.
+     * <p/>
+     * {@link PublicKey} values are converted to JSON Web Key (JWK) representations.
+     * <p/>
      * Array claims can be set as {@link Collection} or {@link JsonArray}, complex claims can be set as {@link Map} or
      * {@link JsonObject}. The members of the array claims can be complex claims.
-     *
+     * <p/>
      * Types of the claims directly supported by this builder are enforced.
      * The 'iss' (issuer), 'sub' (subject), 'upn', 'preferred_username' and 'jti' (token identifier) claims must be of
      * {@link String} type.

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/JwtSignatureBuilder.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/JwtSignatureBuilder.java
@@ -1,5 +1,6 @@
 package io.smallrye.jwt.build;
 
+import java.security.PublicKey;
 import java.security.cert.X509Certificate;
 import java.util.List;
 
@@ -99,6 +100,14 @@ public interface JwtSignatureBuilder extends JwtSignature {
      * @return JwtSignatureBuilder
      */
     JwtSignatureBuilder chain(List<X509Certificate> chain);
+
+    /**
+     * Set JSON Web Key 'jwk' key.
+     *
+     * @param key the public key
+     * @return JwtSignatureBuilder
+     */
+    JwtSignatureBuilder jwk(PublicKey key);
 
     /**
      * Custom JWT signature header.


### PR DESCRIPTION
Fixes #770

This PR makes it easy to set a `jwk` token header, and is also a preparation for the DPoP work.

I'll be planning to do a release once this PR is reviewed and merged