### PR TITLE
Add JavaDocs to DefaultJWTParser constructors and prevent possible NPE

### DIFF
--- a/implementation/jwt-auth/src/main/java/io/smallrye/jwt/auth/principal/DefaultJWTParser.java
+++ b/implementation/jwt-auth/src/main/java/io/smallrye/jwt/auth/principal/DefaultJWTParser.java
@@ -55,17 +55,39 @@ public class DefaultJWTParser implements JWTParser {
     @Inject
     private JWTCallerPrincipalFactory callerPrincipalFactory;
 
+    /**
+     * Default constructor which is required to support a JWTParser injection
+     */
     public DefaultJWTParser() {
     }
 
+    /**
+     * Constructor which initializes DefaultJWTParser with the provided {@link JWTAuthContextInfo} and a new instance of
+     * {@link JWTCallerPrincipalFactory}
+     *
+     * @param authContextInfo {@link JWTAuthContextInfo}
+     */
     public DefaultJWTParser(JWTAuthContextInfo authContextInfo) {
         this(authContextInfo, new JWTCallerPrincipalFactoryProducer().getFactory());
     }
 
+    /**
+     * Constructor which initializes DefaultJWTParser with the provided {@link JWTCallerPrincipalFactory} and a new instance of
+     * {@link JWTAuthContextInfo}
+     *
+     * @param factory {@link JWTCallerPrincipalFactory}
+     */
     public DefaultJWTParser(JWTCallerPrincipalFactory factory) {
-        this(null, factory);
+        this(new JWTAuthContextInfo(), factory);
     }
 
+    /**
+     * Constructor which initializes DefaultJWTParser with the provided {@link JWTAuthContextInfo} and
+     * {@link JWTCallerPrincipalFactory}
+     *
+     * @param authContextInfo {@link JWTAuthContextInfo}
+     * @param factory {@link JWTCallerPrincipalFactory}
+     */
     public DefaultJWTParser(JWTAuthContextInfo authContextInfo, JWTCallerPrincipalFactory factory) {
         this.authContextInfo = authContextInfo;
         this.callerPrincipalFactory = factory;


### PR DESCRIPTION
Fixes #765 

Hi @MikeEdgar Can you please review this is very last PR before the release ? It only adds JavaDocs as users may be thinking the factory is managed somehow when this parser is created directly in the user code. 
It also fixes a possible NPE if the constructor accepting the factory only is used. This constructor supports methods like `parse(token, myPublicKey)` where a new context is created in any case, but if this constructor is used with `parse(token)` which is meant to be used with the injected JWTParser only, then it will cause NPE, so this PR prevents it