### PR TITLE
Check configured signing algorithm when reading the key

### DIFF
--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtClaimsBuilderImpl.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtClaimsBuilderImpl.java
@@ -202,7 +202,7 @@ class JwtClaimsBuilderImpl extends JwtSignatureImpl implements JwtClaimsBuilder,
      */
     @Override
     public JwtSignatureBuilder header(String name, Object value) {
-        if ("alg".equals(name)) {
+        if (HeaderParameterNames.ALGORITHM.equals(name)) {
             return algorithm(toSignatureAlgorithm((String) value));
         } else {
             headers.put(name, value);

--- a/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtBuildConfigSource.java
+++ b/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtBuildConfigSource.java
@@ -22,6 +22,8 @@ public class JwtBuildConfigSource implements ConfigSource {
             JwtBuildUtils.NEW_TOKEN_AUDIENCE_PROPERTY,
             JwtBuildUtils.NEW_TOKEN_LIFESPAN_PROPERTY,
             JwtBuildUtils.NEW_TOKEN_OVERRIDE_CLAIMS_PROPERTY,
+            JwtBuildUtils.NEW_TOKEN_SIGNATURE_ALG_PROPERTY,
+            JwtBuildUtils.NEW_TOKEN_KEY_ENCRYPTION_ALG_PROPERTY,
             JwtBuildUtils.SIGN_KEYSTORE_KEY_ALIAS,
             JwtBuildUtils.ENC_KEYSTORE_KEY_ALIAS));
 

--- a/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtEncryptTest.java
+++ b/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtEncryptTest.java
@@ -359,6 +359,32 @@ public class JwtEncryptTest {
     }
 
     @Test
+    void encryptWithConfiguredEcKeyAndAlgorithmAndA128CBCHS256() throws Exception {
+        JwtBuildConfigSource configSource = JwtSignTest.getConfigSource();
+        configSource.setEncryptionKeyLocation("/ecPublicKey.pem");
+        configSource.setKeyEncryptionAlgorithm("ECDH-ES+A256KW");
+        String jweCompact = null;
+        try {
+            jweCompact = Jwt.claims()
+                    .claim("customClaim", "custom-value")
+                    .jwe()
+                    .keyId("key-enc-key-id")
+                    .contentAlgorithm(ContentEncryptionAlgorithm.A128CBC_HS256)
+                    .encrypt();
+        } finally {
+            configSource.setEncryptionKeyLocation("/publicKey.pem");
+            configSource.setKeyEncryptionAlgorithm(null);
+        }
+
+        checkJweHeaders(jweCompact, "ECDH-ES+A256KW", "A128CBC-HS256", 4);
+
+        JsonWebEncryption jwe = getJsonWebEncryption(jweCompact, getEcPrivateKey());
+
+        JwtClaims claims = JwtClaims.parse(jwe.getPlaintextString());
+        checkJwtClaims(claims);
+    }
+
+    @Test
     void encryptWithConfiguredEcKeyAndContentAlgorithm() throws Exception {
         JwtBuildConfigSource configSource = JwtSignTest.getConfigSource();
         configSource.setEncryptionKeyLocation("/ecPublicKey.pem");


### PR DESCRIPTION
Fixes #784

Signature algorithm configuration is ignored if the signing key is not passed directly or if it is not set as a header property (ex, `Jwt.claims("claims.json").jws().algorithm(SignatureAlgorithm.ES256)`) and must be loaded, thus anything but RS256 will fail. So this PR checks the configuration property early if the header is not already set.

Not a problem for the encryption case.