### PR TITLE
fetch keys in ContextProvider

### DIFF
--- a/doc/modules/ROOT/pages/configuration.adoc
+++ b/doc/modules/ROOT/pages/configuration.adoc
@@ -80,6 +80,7 @@ SmallRye JWT supports many properties which can be used to customize the token p
 |smallrye.jwt.keystore.verify.key.alias||This property has to be set to identify a public verification key which will be extracted from `KeyStore` from a matching certificate if `mp.jwt.verify.publickey.location` points to a `KeyStore` file.
 |smallrye.jwt.keystore.decrypt.key.alias||This property has to be set to identify a private decryption key if `mp.jwt.decrypt.key.location` points to a `KeyStore` file.
 |smallrye.jwt.keystore.decrypt.key.password||This property may be set if a private decryption key's password in `KeyStore` is different to `smallrye.jwt.keystore.password` when `mp.jwt.decrypt.key.location` points to a `KeyStore` file.
+|smallrye.jwt.resolve-remote-keys-at-startup|false|Set this property to `true` to resolve the remote keys at the application startup.
 |===
 
 = Create JsonWebToken with JWTParser


### PR DESCRIPTION
add option to fetch Verification keys only once via ContextProvider. This option is disabled by default for backwards compatibility.
Resolves #478
Contributes to https://github.com/quarkusio/quarkus/issues/36352