### PR TITLE
Revert "Fix the Sonar plugin integration"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,10 +76,10 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-java@v1
         with:
-          java-version: 17
+          java-version: 11
 
       - name: sonar
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           SONAR_TOKEN: ${{secrets.SONAR_TOKEN}}
-        run: mvn -B verify --file pom.xml -Pcoverage javadoc:javadoc sonar:sonar -Dsonar.projectKey=smallrye_smallrye-jwt -Dsonar.token=$SONAR_TOKEN
+        run: mvn -B verify --file pom.xml -Pcoverage javadoc:javadoc sonar:sonar -Dsonar.projectKey=smallrye_smallrye-jwt -Dsonar.login=$SONAR_TOKEN


### PR DESCRIPTION
Reverts smallrye/smallrye-jwt#778 for now as it failed the release insisting on improving the coverage, unless we can skip it for the release task only ?
Mike, Roberto, what do you think ? 
