### PR TITLE
Fix IllegalArgumentException when using EDDSA signature algorithm

### DIFF
--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtSignatureImpl.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtSignatureImpl.java
@@ -267,7 +267,7 @@ class JwtSignatureImpl implements JwtSignature {
 
         // Try PEM format first - default to RS256 if the algorithm is unknown
         Key key = KeyUtils.tryAsPemSigningPrivateKey(keyContent,
-                (alg == null ? SignatureAlgorithm.RS256 : SignatureAlgorithm.fromAlgorithm(alg)));
+                (alg == null ? SignatureAlgorithm.RS256 : SignatureAlgorithm.fromAlgorithm(alg.toUpperCase())));
         if (key == null) {
             if (kid == null) {
                 kid = JwtBuildUtils.getConfigProperty(JwtBuildUtils.SIGN_KEY_ID_PROPERTY, String.class);
@@ -281,7 +281,7 @@ class JwtSignatureImpl implements JwtSignature {
             if (jwk != null) {
                 // if the user has already set the algorithm header then JWK `alg` header, if set, must match it
                 key = KeyUtils.getPrivateOrSecretSigningKey(jwk,
-                        (alg == null ? null : SignatureAlgorithm.fromAlgorithm(alg)));
+                        (alg == null ? null : SignatureAlgorithm.fromAlgorithm(alg.toUpperCase())));
                 if (key != null) {
                     // if the algorithm header is not set then use JWK `alg`
                     if (alg == null && jwk.getAlgorithm() != null) {


### PR DESCRIPTION
This fixes `java.lang.IllegalArgumentException: No enum constant
io.smallrye.jwt.algorithm.SignatureAlgorithm.EdDSA` when `EDDSA` is set through
`smallrye.jwt.new-token.signature-algorithm` property, or when it is set with
`JwtClaimsBuilderImpl`.

Currently, `JwtSignatureImpl.getConfiguredSignatureAlgorithm()` returns
algorithm name as a String from `SignatureAlgorithm.algorithmName` field,
in case of it being loaded from a configuration file.

If the algorithm was set through `JwtClaimsBuilderImpl`, the value is returned
as-is from the header, which means `EdDSA`, because this is how
`JwtClaimsBuilderImpl` puts the value there.

This name is then used to get appropriate `SignatureAlgorithm` enum variant
in `JwtSignatureImpl.getSigningKeyFromKeyContent(String)`, but without
using `toUpperCase()` on the name, causing exception when `EdDSA` is used.

The fix adds `toUpperCase()` call on algorithm name before passing it
to `SignatureAlgorithm.fromAlgorithm(String)`.