### PR TITLE
Fix IllegalArgumentException when using EdDSA signature algorithm

### DIFF
--- a/implementation/common/pom.xml
+++ b/implementation/common/pom.xml
@@ -57,6 +57,10 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>
+    <dependency>
+      <groupId>net.jqwik</groupId>
+      <artifactId>jqwik</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/implementation/common/src/main/java/io/smallrye/jwt/algorithm/SignatureAlgorithm.java
+++ b/implementation/common/src/main/java/io/smallrye/jwt/algorithm/SignatureAlgorithm.java
@@ -22,9 +22,9 @@ public enum SignatureAlgorithm {
     PS384("PS384"),
     PS512("PS512");
 
-    private String algorithmName;
+    private final String algorithmName;
 
-    private SignatureAlgorithm(String algorithmName) {
+    SignatureAlgorithm(String algorithmName) {
         this.algorithmName = algorithmName;
     }
 

--- a/implementation/common/src/main/java/io/smallrye/jwt/algorithm/SignatureAlgorithm.java
+++ b/implementation/common/src/main/java/io/smallrye/jwt/algorithm/SignatureAlgorithm.java
@@ -1,5 +1,7 @@
 package io.smallrye.jwt.algorithm;
 
+import java.util.StringJoiner;
+
 /**
  * JWT JSON Web Signature Algorithms.
  *
@@ -31,6 +33,19 @@ public enum SignatureAlgorithm {
     }
 
     public static SignatureAlgorithm fromAlgorithm(String algorithmName) {
-        return SignatureAlgorithm.valueOf(algorithmName);
+        try {
+            return SignatureAlgorithm.valueOf(algorithmName.toUpperCase());
+        } catch (Exception e) {
+            throw new IllegalArgumentException(
+                    "Invalid signature algorithm name: " + algorithmName + ", expected one of: " + getValidNames(), e);
+        }
+    }
+
+    private static String getValidNames() {
+        var names = new StringJoiner(", ");
+        for (var alg : values()) {
+            names.add(alg.getAlgorithm());
+        }
+        return names.toString();
     }
 }

--- a/implementation/common/src/test/java/io/smallrye/jwt/util/SignatureAlgorithmTest.java
+++ b/implementation/common/src/test/java/io/smallrye/jwt/util/SignatureAlgorithmTest.java
@@ -1,0 +1,71 @@
+package io.smallrye.jwt.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collection;
+import java.util.HashSet;
+
+import org.junit.platform.commons.util.StringUtils;
+
+import io.smallrye.jwt.algorithm.SignatureAlgorithm;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+import net.jqwik.api.lifecycle.BeforeContainer;
+
+public class SignatureAlgorithmTest {
+
+    // all the names that can be used without throwing exception
+    private static final Collection<String> ACCEPTED_NAMES = new HashSet<>();
+
+    @BeforeContainer
+    static void setUp() {
+        for (var alg : SignatureAlgorithm.values()) {
+            generateAcceptedNames(alg.name().toCharArray(), 0);
+        }
+    }
+
+    @Property
+    void givenAlgorithm_shouldGetNonBlankAlgorithmName(@ForAll SignatureAlgorithm algorithm) {
+        assertTrue(StringUtils.isNotBlank(algorithm.getAlgorithm()));
+    }
+
+    @Provide
+    static Arbitrary<String> validNames() {
+        return Arbitraries.of(ACCEPTED_NAMES).dontShrink();
+    }
+
+    @Property
+    void givenValidAlgorithmName_shouldReturnAppropriateAlgorithm(@ForAll("validNames") String name) {
+        assertEquals(name.toUpperCase(), SignatureAlgorithm.fromAlgorithm(name).getAlgorithm().toUpperCase());
+    }
+
+    @Provide
+    static Arbitrary<String> invalidNames() {
+        return Arbitraries.strings()
+                .injectNull(0.0005)
+                .filter((s) -> !ACCEPTED_NAMES.contains(s));
+    }
+
+    @Property
+    void givenInvalidAlgorithmName_shouldThrowIllegalArgumentException(@ForAll("invalidNames") String name) {
+        assertThrows(IllegalArgumentException.class, () -> SignatureAlgorithm.fromAlgorithm(name));
+    }
+
+    private static void generateAcceptedNames(char[] name, int index) {
+        if (index == name.length) {
+            ACCEPTED_NAMES.add(new String(name));
+        } else if (Character.isLetter(name[index])) {
+            name[index] = Character.toUpperCase(name[index]);
+            generateAcceptedNames(name, index + 1);
+            name[index] = Character.toLowerCase(name[index]);
+            generateAcceptedNames(name, index + 1);
+        } else {
+            generateAcceptedNames(name, index + 1);
+        }
+    }
+}

--- a/implementation/common/src/test/resources/junit-platform.properties
+++ b/implementation/common/src/test/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+jqwik.database=

--- a/implementation/jwt-build/pom.xml
+++ b/implementation/jwt-build/pom.xml
@@ -75,6 +75,10 @@
       <artifactId>junit-jupiter</artifactId>
     </dependency>
     <dependency>
+      <groupId>net.jqwik</groupId>
+      <artifactId>jqwik</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.parsson</groupId>
       <artifactId>parsson</artifactId>
     </dependency>

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtSignatureImpl.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtSignatureImpl.java
@@ -200,7 +200,7 @@ class JwtSignatureImpl implements JwtSignature {
             try {
                 alg = JwtBuildUtils.getConfigProperty(JwtBuildUtils.NEW_TOKEN_SIGNATURE_ALG_PROPERTY, String.class);
                 if (alg != null) {
-                    alg = SignatureAlgorithm.valueOf(alg.toUpperCase()).getAlgorithm();
+                    alg = SignatureAlgorithm.fromAlgorithm(alg).getAlgorithm();
                     headers.put(HeaderParameterNames.ALGORITHM, alg);
                 }
             } catch (Exception ex) {

--- a/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/SignatureAlgorithmSettingTest.java
+++ b/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/SignatureAlgorithmSettingTest.java
@@ -1,0 +1,156 @@
+package io.smallrye.jwt.build;
+
+import static io.smallrye.jwt.build.JwtSignJwkTest.getVerifiedJws;
+import static io.smallrye.jwt.build.JwtSignTest.getConfigSource;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.HashMap;
+import java.util.Map.Entry;
+
+import org.jose4j.jwk.PublicJsonWebKey;
+import org.jose4j.jws.JsonWebSignature;
+import org.jose4j.jwt.JwtClaims;
+import org.jose4j.jwx.HeaderParameterNames;
+
+import io.smallrye.jwt.algorithm.SignatureAlgorithm;
+import io.smallrye.jwt.util.KeyUtils;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+import net.jqwik.api.Tuple;
+import net.jqwik.api.Tuple.Tuple2;
+import net.jqwik.api.lifecycle.AfterTry;
+import net.jqwik.api.lifecycle.BeforeContainer;
+
+public class SignatureAlgorithmSettingTest {
+
+    // all the names that can be used without throwing an exception, and their JWKs
+    private static final HashMap<String, Tuple2<String, String>> ACCEPTED_NAMES = new HashMap<>();
+
+    @BeforeContainer
+    static void setUp() {
+        generateAcceptedNames();
+    }
+
+    @AfterTry
+    void afterTry() {
+        var configSource = getConfigSource();
+        configSource.setSignatureAlgorithm(null);
+        configSource.setSigningKeyLocation("/privateKey.pem");
+    }
+
+    @Provide
+    static Arbitrary<Entry<String, Tuple2<String, String>>> validNames() {
+        return Arbitraries.of(ACCEPTED_NAMES.entrySet()).dontShrink();
+    }
+
+    @Property
+    void givenAlgorithmHeader_shouldSignClaims(@ForAll("validNames") Entry<String, Tuple2<String, String>> entry)
+            throws Exception {
+        // given
+        var alg = entry.getKey();
+        getConfigSource().setSigningKeyLocation(entry.getValue().get1());
+        var publicKey = entry.getValue().get2();
+
+        // when
+        var jwt = Jwt.claims()
+                .issuer("https://issuer.com")
+                .jws()
+                .header(HeaderParameterNames.ALGORITHM, alg)
+                .header("customHeader", "custom-header-value")
+                .sign();
+
+        JsonWebSignature jws;
+        if (alg.toUpperCase().startsWith("HS")) {
+            jws = getVerifiedJws(jwt, KeyUtils.readSigningKey(publicKey, null, SignatureAlgorithm.fromAlgorithm(alg)));
+        } else if (publicKey.endsWith(".pem")) {
+            jws = getVerifiedJws(jwt, KeyUtils.readPublicKey(publicKey));
+        } else {
+            var keyContent = KeyUtils.readKeyContent(publicKey);
+            jws = getVerifiedJws(jwt, PublicJsonWebKey.Factory.newPublicJwk(keyContent).getPublicKey());
+        }
+        var claims = JwtClaims.parse(jws.getPayload());
+
+        // then
+        assertEquals(4, claims.getClaimsMap().size());
+        assertEquals("https://issuer.com", claims.getIssuer());
+        assertEquals("custom-header-value", jws.getHeader("customHeader"));
+    }
+
+    @Provide
+    static Arbitrary<Tuple2<String, String>> invalidNames() {
+        return Arbitraries.strings()
+                .injectNull(0.0005)
+                .filter((s) -> !ACCEPTED_NAMES.containsKey(s))
+                .map((s) -> Tuple.of(s, ",/edEcPrivateKey.jwk"));
+    }
+
+    @Property
+    void givenInvalidAlgorithmHeader_shouldThrowJwtSignatureExceptionOnSign(
+            @ForAll("invalidNames") Tuple2<String, String> tuple) {
+        // given
+        final var alg = tuple.get1();
+        getConfigSource().setSigningKeyLocation(tuple.get2());
+
+        // when, then
+        assertThrows(JwtSignatureException.class, () -> Jwt.claims()
+                .issuer("https://issuer.com")
+                .jws()
+                .header(HeaderParameterNames.ALGORITHM, alg)
+                .header("customHeader", "custom-header-value")
+                .sign());
+    }
+
+    private static void generateAcceptedNames() {
+        for (var alg : SignatureAlgorithm.values()) {
+            var name = alg.name().toCharArray();
+            switch (alg) {
+                case RS256:
+                case RS384:
+                case RS512:
+                case PS256:
+                case PS384:
+                case PS512:
+                    generateAcceptedNamesForAlgorithm(name, 0, Tuple.of("/privateKey.pem", "/publicKey.pem"));
+                    break;
+                case ES256:
+                    generateAcceptedNamesForAlgorithm(name, 0, Tuple.of("/ecPrivateP256Key.jwk", "/ecPublicP256Key.jwk"));
+                    break;
+                case ES384:
+                    generateAcceptedNamesForAlgorithm(name, 0, Tuple.of("/ecPrivateP384Key.jwk", "/ecPublicP384Key.jwk"));
+                    break;
+                case ES512:
+                    generateAcceptedNamesForAlgorithm(name, 0, Tuple.of("/ecPrivateP512Key.jwk", "/ecPublicP512Key.jwk"));
+                    break;
+                case EDDSA:
+                    generateAcceptedNamesForAlgorithm(name, 0, Tuple.of("/edEcPrivateKey.jwk", "/edEcPublicKey.jwk"));
+                    break;
+                case HS256:
+                    generateAcceptedNamesForAlgorithm(name, 0, Tuple.of("/privateKeyHS256.jwk", "/privateKeyHS256.jwk"));
+                    break;
+                case HS384:
+                    generateAcceptedNamesForAlgorithm(name, 0, Tuple.of("/privateKeyHS384.jwk", "/privateKeyHS384.jwk"));
+                    break;
+                case HS512:
+                    generateAcceptedNamesForAlgorithm(name, 0, Tuple.of("/privateKeyHS512.jwk", "/privateKeyHS512.jwk"));
+                    break;
+            }
+        }
+    }
+
+    private static void generateAcceptedNamesForAlgorithm(char[] name, int index, Tuple2<String, String> keys) {
+        if (index == name.length) {
+            ACCEPTED_NAMES.put(new String(name), keys);
+        } else if (Character.isLetter(name[index])) {
+            name[index] = Character.toUpperCase(name[index]);
+            generateAcceptedNamesForAlgorithm(name, index + 1, keys);
+            name[index] = Character.toLowerCase(name[index]);
+            generateAcceptedNamesForAlgorithm(name, index + 1, keys);
+        } else {
+            generateAcceptedNamesForAlgorithm(name, index + 1, keys);
+        }
+    }
+}

--- a/implementation/jwt-build/src/test/resources/ecPrivateP256Key.jwk
+++ b/implementation/jwt-build/src/test/resources/ecPrivateP256Key.jwk
@@ -1,0 +1,7 @@
+{
+  "kty": "EC",
+  "d": "qleL9xfWvcy_e9oVrmDq7xNV-ccaTvJSQESkGtANNI4",
+  "crv": "P-256",
+  "x": "hVhzRmteLj6Yt777gw9WplTAdR7kuezBOCwETkAIWu0",
+  "y": "uQx5yaaExxI9ADFcLRthEOzigTtx6vYj8xhHzAf1iWQ"
+}

--- a/implementation/jwt-build/src/test/resources/ecPrivateP384Key.jwk
+++ b/implementation/jwt-build/src/test/resources/ecPrivateP384Key.jwk
@@ -1,0 +1,7 @@
+{
+  "kty": "EC",
+  "d": "59PRCUqv0cQjL1Uz_BMMZE6rxAxn6eEEoFdhtgDZD1TVDbngcUoNrexWODMlTZ6-",
+  "crv": "P-384",
+  "x": "M7TTaIg3pXo6by_Nzzhd5Y-OiXcEanewiDV7zlY6QQ7jOX4aldLaVh7jqg12XRBM",
+  "y": "okvDeCm7j241e3p8a0OaWKLmOT0vQfmruP-U1Odb4uGaLPPcUxSt9-Ybe1GiDHci"
+}

--- a/implementation/jwt-build/src/test/resources/ecPrivateP512Key.jwk
+++ b/implementation/jwt-build/src/test/resources/ecPrivateP512Key.jwk
@@ -1,0 +1,7 @@
+{
+  "kty": "EC",
+  "d": "APWg4gwmg2LrT3DPwyrpUmnreyv-4mTFh9SaJkju6nfK3STtEPS0t5fLuSjVxas5sAzVd7FL_7oicEX1RTL1y_Ee",
+  "crv": "P-521",
+  "x": "AGsx0kQrTvqnXUCt-fzu5Vs-08MGOyp92L5HI091677Df-anW2_AmokEzd_QQ_GyYC1lUt9rq38MSyVLN0Y9Myf9",
+  "y": "ACAIxD-KjJU6Om8WxdtwhygaW0waCObEYOV0WX_QSGnQvXDnG1Q90bH1gj1FOabx5XesnF3GblLwWOSw_t0BNs8a"
+}

--- a/implementation/jwt-build/src/test/resources/ecPublicP256Key.jwk
+++ b/implementation/jwt-build/src/test/resources/ecPublicP256Key.jwk
@@ -1,0 +1,6 @@
+{
+  "kty": "EC",
+  "crv": "P-256",
+  "x": "hVhzRmteLj6Yt777gw9WplTAdR7kuezBOCwETkAIWu0",
+  "y": "uQx5yaaExxI9ADFcLRthEOzigTtx6vYj8xhHzAf1iWQ"
+}

--- a/implementation/jwt-build/src/test/resources/ecPublicP384Key.jwk
+++ b/implementation/jwt-build/src/test/resources/ecPublicP384Key.jwk
@@ -1,0 +1,6 @@
+{
+  "kty": "EC",
+  "crv": "P-384",
+  "x": "M7TTaIg3pXo6by_Nzzhd5Y-OiXcEanewiDV7zlY6QQ7jOX4aldLaVh7jqg12XRBM",
+  "y": "okvDeCm7j241e3p8a0OaWKLmOT0vQfmruP-U1Odb4uGaLPPcUxSt9-Ybe1GiDHci"
+}

--- a/implementation/jwt-build/src/test/resources/ecPublicP512Key.jwk
+++ b/implementation/jwt-build/src/test/resources/ecPublicP512Key.jwk
@@ -1,0 +1,6 @@
+{
+  "kty": "EC",
+  "crv": "P-521",
+  "x": "AGsx0kQrTvqnXUCt-fzu5Vs-08MGOyp92L5HI091677Df-anW2_AmokEzd_QQ_GyYC1lUt9rq38MSyVLN0Y9Myf9",
+  "y": "ACAIxD-KjJU6Om8WxdtwhygaW0waCObEYOV0WX_QSGnQvXDnG1Q90bH1gj1FOabx5XesnF3GblLwWOSw_t0BNs8a"
+}

--- a/implementation/jwt-build/src/test/resources/junit-platform.properties
+++ b/implementation/jwt-build/src/test/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+jqwik.database=

--- a/implementation/jwt-build/src/test/resources/privateKeyHS256.jwk
+++ b/implementation/jwt-build/src/test/resources/privateKeyHS256.jwk
@@ -1,0 +1,5 @@
+{
+  "kty": "oct",
+  "k":"yZfiEYLkRfJDPLnoc5iJ34AO621c_52w3tqb3s99upM",
+  "alg":"HS256"
+}

--- a/implementation/jwt-build/src/test/resources/privateKeyHS384.jwk
+++ b/implementation/jwt-build/src/test/resources/privateKeyHS384.jwk
@@ -1,0 +1,5 @@
+{
+  "kty": "oct",
+  "k":"HoBtCwyDdNQ7iLCvGd4vxpKq2Fpr4BASGXbzi5JhT8S9NC0vhtpNqhuXcJriNQ3r",
+  "alg":"HS384"
+}

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
     <version.jose4j>0.9.6</version.jose4j>
 
     <!-- Testing -->
+    <version.jqwik>1.8.5</version.jqwik>
     <version.junit4>4.13.2</version.junit4>
     <version.mokito>5.12.0</version.mokito>
     <version.bouncycastle>1.70</version.bouncycastle>
@@ -150,6 +151,12 @@
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>${version.junit4}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>net.jqwik</groupId>
+        <artifactId>jqwik</artifactId>
+        <version>${version.jqwik}</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
This fixes `java.lang.IllegalArgumentException: No enum constant
io.smallrye.jwt.algorithm.SignatureAlgorithm.EdDSA` when `EDDSA` is set through
`smallrye.jwt.new-token.signature-algorithm` property, or when it is set with
`JwtClaimsBuilderImpl`.

Currently, `JwtSignatureImpl.getConfiguredSignatureAlgorithm()` returns
algorithm name as a String from `SignatureAlgorithm.algorithmName` field,
in case of it being loaded from a configuration file.

If the algorithm was set through `JwtClaimsBuilderImpl`, the value is returned
as-is from the header, which means `EdDSA`, because this is how
`JwtClaimsBuilderImpl` puts the value there.

This name is then used to get appropriate `SignatureAlgorithm` enum variant
in `JwtSignatureImpl.getSigningKeyFromKeyContent(String)`, but without
using `toUpperCase()` on the name, causing exception when `EdDSA` is used.

The fix adds `toUpperCase()` call on algorithm name before passing it
to `SignatureAlgorithm.valueOf(String)`.