### PR TITLE
Fix IllegalArgumentException when using EdDSA signature algorithm

### DIFF
--- a/implementation/common/src/main/java/io/smallrye/jwt/algorithm/SignatureAlgorithm.java
+++ b/implementation/common/src/main/java/io/smallrye/jwt/algorithm/SignatureAlgorithm.java
@@ -1,5 +1,7 @@
 package io.smallrye.jwt.algorithm;
 
+import java.util.StringJoiner;
+
 /**
  * JWT JSON Web Signature Algorithms.
  *
@@ -20,9 +22,9 @@ public enum SignatureAlgorithm {
     PS384("PS384"),
     PS512("PS512");
 
-    private String algorithmName;
+    private final String algorithmName;
 
-    private SignatureAlgorithm(String algorithmName) {
+    SignatureAlgorithm(String algorithmName) {
         this.algorithmName = algorithmName;
     }
 
@@ -31,6 +33,19 @@ public enum SignatureAlgorithm {
     }
 
     public static SignatureAlgorithm fromAlgorithm(String algorithmName) {
-        return SignatureAlgorithm.valueOf(algorithmName);
+        try {
+            return SignatureAlgorithm.valueOf(algorithmName.toUpperCase());
+        } catch (Exception e) {
+            throw new IllegalArgumentException(
+                    "Invalid signature algorithm name: " + algorithmName + ", expected one of: " + getValidNames(), e);
+        }
+    }
+
+    private static String getValidNames() {
+        var names = new StringJoiner(", ");
+        for (var alg : values()) {
+            names.add(alg.getAlgorithm());
+        }
+        return names.toString();
     }
 }


### PR DESCRIPTION
This fixes `java.lang.IllegalArgumentException: No enum constant
io.smallrye.jwt.algorithm.SignatureAlgorithm.EdDSA` when `EDDSA` is set through
`smallrye.jwt.new-token.signature-algorithm` property, or when it is set with
`JwtClaimsBuilderImpl`.

Currently, `JwtSignatureImpl.getConfiguredSignatureAlgorithm()` returns
algorithm name as a String from `SignatureAlgorithm.algorithmName` field,
in case of it being loaded from a configuration file.

If the algorithm was set through `JwtClaimsBuilderImpl`, the value is returned
as-is from the header, which means `EdDSA`, because this is how
`JwtClaimsBuilderImpl` puts the value there.

This name is then used to get appropriate `SignatureAlgorithm` enum variant
in `JwtSignatureImpl.getSigningKeyFromKeyContent(String)`, but without
using `toUpperCase()` on the name, causing exception when `EdDSA` is used.

The fix adds `toUpperCase()` call on algorithm name before passing it
to `SignatureAlgorithm.valueOf(String)`.