### PR TITLE
Add smallrye.jwt.verify.secretkey property for inlining secret keys

### DIFF
--- a/doc/modules/ROOT/pages/configuration.adoc
+++ b/doc/modules/ROOT/pages/configuration.adoc
@@ -39,6 +39,7 @@ SmallRye JWT supports many properties which can be used to customize the token p
 [cols="<m,<m,<2",options="header"]
 |===
 |Property Name|Default|Description
+|smallrye.jwt.verify.secretkey|none|Secret key supplied as a string.
 |smallrye.jwt.verify.key.location|NONE|Location of the verification key which can point to both public and secret keys. Secret keys can only be in the JWK format. Note that 'mp.jwt.verify.publickey.location' will be ignored if this property is set.
 |smallrye.jwt.verify.algorithm|`RS256`|Signature algorithm. Set it to `ES256` to support the Elliptic Curve signature algorithm. This property is deprecated, use `mp.jwt.verify.publickey.algorithm`.
 |smallrye.jwt.verify.key-format|`ANY`|Set this property to a specific key format such as `PEM_KEY`, `PEM_CERTIFICATE`, `JWK` or `JWK_BASE64URL` to optimize the way the verification key is loaded.

--- a/implementation/jwt-auth/src/main/java/io/smallrye/jwt/auth/principal/JWTAuthContextInfo.java
+++ b/implementation/jwt-auth/src/main/java/io/smallrye/jwt/auth/principal/JWTAuthContextInfo.java
@@ -46,6 +46,7 @@ public class JWTAuthContextInfo {
     private int clockSkew = 60;
     private String publicKeyLocation;
     private String publicKeyContent;
+    private String secretKeyContent;
     private String decryptionKeyLocation;
     private String decryptionKeyContent;
     private Integer jwksRefreshInterval = 60;
@@ -115,6 +116,7 @@ public class JWTAuthContextInfo {
         this.clockSkew = orig.getClockSkew();
         this.publicKeyLocation = orig.getPublicKeyLocation();
         this.publicKeyContent = orig.getPublicKeyContent();
+        this.secretKeyContent = orig.getSecretKeyContent();
         this.decryptionKeyLocation = orig.getDecryptionKeyLocation();
         this.decryptionKeyContent = orig.getDecryptionKeyContent();
         this.jwksRefreshInterval = orig.getJwksRefreshInterval();
@@ -247,6 +249,14 @@ public class JWTAuthContextInfo {
 
     public void setPublicKeyContent(String publicKeyContent) {
         this.publicKeyContent = publicKeyContent;
+    }
+
+    public String getSecretKeyContent() {
+        return this.secretKeyContent;
+    }
+
+    public void setSecretKeyContent(String secretKeyContent) {
+        this.secretKeyContent = secretKeyContent;
     }
 
     public String getDecryptionKeyContent() {
@@ -422,6 +432,7 @@ public class JWTAuthContextInfo {
                 ", tokenAge=" + tokenAge +
                 ", publicKeyLocation='" + publicKeyLocation + '\'' +
                 ", publicKeyContent='" + publicKeyContent + '\'' +
+                ", secretKeyContent='" + secretKeyContent + '\'' +
                 ", decryptionKeyLocation='" + decryptionKeyLocation + '\'' +
                 ", decryptionKeyContent='" + decryptionKeyContent + '\'' +
                 ", jwksRefreshInterval=" + jwksRefreshInterval +

--- a/implementation/jwt-auth/src/main/java/io/smallrye/jwt/auth/principal/KeyLocationResolver.java
+++ b/implementation/jwt-auth/src/main/java/io/smallrye/jwt/auth/principal/KeyLocationResolver.java
@@ -100,9 +100,14 @@ public class KeyLocationResolver extends AbstractKeyLocationResolver implements 
             return;
         }
 
-        String content = authContextInfo.getPublicKeyContent() != null
-                ? authContextInfo.getPublicKeyContent()
-                : readKeyContent(authContextInfo.getPublicKeyLocation());
+        String content = null;
+        if (authContextInfo.getPublicKeyContent() != null) {
+            content = authContextInfo.getPublicKeyContent();
+        } else if (authContextInfo.getSecretKeyContent() != null) {
+            content = authContextInfo.getSecretKeyContent();
+        } else {
+            content = readKeyContent(authContextInfo.getPublicKeyLocation());
+        }
 
         // Try to init the verification key from the local PEM or JWK(S) content
         if (mayBeFormat(KeyFormat.PEM_KEY)) {

--- a/implementation/jwt-auth/src/main/java/io/smallrye/jwt/config/ConfigLogging.java
+++ b/implementation/jwt-auth/src/main/java/io/smallrye/jwt/config/ConfigLogging.java
@@ -39,4 +39,12 @@ public interface ConfigLogging extends BasicLogger {
     @Message(id = 3006, value = "'%s' property is deprecated and will be removed in a future version. " +
             "Use '%s ' property instead")
     void replacedConfig(String originalConfig, String newConfig);
+
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 3007, value = "Public key is configured but either the secret key or key location are also configured and will be ignored")
+    void publicKeyConfiguredButOtherKeyPropertiesAreAlsoUsed();
+
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 3008, value = "Secret key is configured but the key location is also configured and will be ignored")
+    void secretKeyConfiguredButKeyLocationIsAlsoUsed();
 }


### PR DESCRIPTION
It will make it possible to use env vars to pass the signing secret key information, as asked for in https://github.com/quarkusio/quarkus/discussions/42550.

In fact, passing the secret key content using the public key property also works but it is not great asking users to use that property 