### PR TITLE
Remove the @since tag for smallrye.jwt.verify.secretkey

### DIFF
--- a/implementation/jwt-auth/src/main/java/io/smallrye/jwt/config/JWTAuthContextInfoProvider.java
+++ b/implementation/jwt-auth/src/main/java/io/smallrye/jwt/config/JWTAuthContextInfoProvider.java
@@ -219,9 +219,6 @@ public class JWTAuthContextInfoProvider {
     @ConfigProperty(name = "mp.jwt.verify.publickey", defaultValue = NONE)
     private String mpJwtPublicKey;
 
-    /**
-     * @since 4.5.4
-     */
     @Inject
     @ConfigProperty(name = "smallrye.jwt.verify.secretkey", defaultValue = NONE)
     private String jwtSecretKey;


### PR DESCRIPTION
Hi Mike, I thought it could cause some confusion since all other `@since` tags are attached to standard properties and refer to the MP JWT spec versions