### PR TITLE
Fix a key location comparison in case of HS256

### DIFF
--- a/implementation/jwt-auth/src/main/java/io/smallrye/jwt/config/JWTAuthContextInfoProvider.java
+++ b/implementation/jwt-auth/src/main/java/io/smallrye/jwt/config/JWTAuthContextInfoProvider.java
@@ -841,7 +841,7 @@ public class JWTAuthContextInfoProvider {
             resolvedAlgorithm = mpJwtPublicKeyAlgorithm;
         } else if (signatureAlgorithm.isPresent()) {
             if (signatureAlgorithm.get().getAlgorithm().startsWith("HS")) {
-                if (resolvedVerifyKeyLocation == mpJwtLocation) {
+                if (!NONE.equals(resolvedVerifyKeyLocation) && resolvedVerifyKeyLocation == mpJwtLocation) {
                     throw ConfigMessages.msg.hmacNotSupported();
                 }
             } else {


### PR DESCRIPTION
Fixes #817.

It is a minor follow up to #815.
In case of `HS256` the code on `main` checks if the resolvedLocation has been assigned to the MP JWT (public) key location property and fails if it is the case. But in #815, a new `smallrye.jwt.verify.secretkey` property is used thus the resolved location, even though it remains assigned by default to the MP JWT location, is `NONE`.

So this PR adds an extra check. Unfortunately tests in `testsuite/basic` for #815 are not using application.properties and it was missed. Tested at https://github.com/quarkusio/quarkus/pull/42629, though as suggested earlier, some good clean up of tests and also of the initial bootstrap code would have to be done at some point