### PR TITLE
Allow to build JWT from JSON string

### DIFF
--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/Jwt.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/Jwt.java
@@ -91,6 +91,16 @@ public final class Jwt {
     }
 
     /**
+     * Creates a new instance of {@link JwtClaimsBuilder} from a JSON string.
+     *
+     * @param json JSON string
+     * @return {@link JwtClaimsBuilder}
+     */
+    public static JwtClaimsBuilder claimsJson(String json) {
+        return JwtProvider.provider().claimsJson(json);
+    }
+
+    /**
      * Creates a new instance of {@link JwtClaimsBuilder} from {@link JsonWebToken}.
      *
      * @param jwt JsonWebToken token.
@@ -310,6 +320,23 @@ public final class Jwt {
     }
 
     /**
+     * Sign the claims from a JSON string using 'RS256' algorithm with a private RSA key
+     * loaded from the location set with the "smallrye.jwt.sign.key-location".
+     * Private RSA key of size 2048 bits or larger MUST be used.
+     *
+     * The 'iat' (issued at time), 'exp' (expiration time) and 'jit' (unique token identifier) claims
+     * will be set and the `iss` issuer claim may be set by the implementation unless they have already been set.
+     * See {@link JwtClaimsBuilder} description for more information.
+     *
+     * @param json JSON string
+     * @return signed JWT token
+     * @throws JwtSignatureException the exception if the signing operation has failed
+     */
+    public static String signJson(String json) {
+        return claimsJson(json).sign();
+    }
+
+    /**
      * Encrypt the claims loaded from a JSON resource using 'RSA-OAEP-256' algorithm with a public RSA key
      * loaded from the location set with the "smallrye.jwt.encrypt.key-location".
      * Public RSA key of size 2048 bits or larger MUST be used.
@@ -360,6 +387,23 @@ public final class Jwt {
      */
     public static String encrypt(JsonObject jsonObject) {
         return claims(jsonObject).jwe().encrypt();
+    }
+
+    /**
+     * Encrypt the claims from a JSON string using 'RSA-OAEP-256' algorithm with a public RSA key
+     * loaded from the location set with the "smallrye.jwt.encrypt.key-location".
+     * Public RSA key of size 2048 bits or larger MUST be used.
+     *
+     * The 'iat' (issued at time), 'exp' (expiration time) and 'jit' (unique token identifier) claims
+     * will be set and the `iss` issuer claim may be set by the implementation unless they have already been set.
+     * See {@link JwtClaimsBuilder} description for more information.
+     *
+     * @param json JSON string
+     * @return encrypted JWT token
+     * @throws JwtEncryptionException the exception if the encryption operation has failed
+     */
+    public static String encryptJson(String json) {
+        return claimsJson(json).jwe().encrypt();
     }
 
     /**
@@ -416,5 +460,23 @@ public final class Jwt {
      */
     public static String innerSignAndEncrypt(JsonObject jsonObject) {
         return claims(jsonObject).innerSign().encrypt();
+    }
+
+    /**
+     * Sign the claims from a JSON string using 'RS256' algorithm with a private RSA key
+     * loaded from the location set with the "smallrye.jwt.sign.key-location" and encrypt the inner JWT using
+     * 'RSA-OAEP-256' algorithm with a public RSA key loaded from the location set with the "smallrye.jwt.encrypt.key-location".
+     * Public RSA key of size 2048 bits or larger MUST be used.
+     *
+     * The 'iat' (issued at time), 'exp' (expiration time) and 'jit' (unique token identifier) claims
+     * will be set and the `iss` issuer claim may be set by the implementation unless they have already been set.
+     * See {@link JwtClaimsBuilder} description for more information.
+     *
+     * @param json JSON string
+     * @return encrypted JWT token
+     * @throws JwtEncryptionException the exception if the encryption operation has failed
+     */
+    public static String innerSignAndEncryptJson(String json) {
+        return claimsJson(json).innerSign().encrypt();
     }
 }

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtBuildUtils.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtBuildUtils.java
@@ -139,6 +139,14 @@ public class JwtBuildUtils {
         }
     }
 
+    static JwtClaims parseJwtContent(String jwtContent) {
+        try {
+            return JwtClaims.parse(jwtContent);
+        } catch (Exception ex) {
+            throw ImplMessages.msg.failureToParseJWTClaims(ex.getMessage(), ex);
+        }
+    }
+
     static PrivateKey readPrivateKeyFromKeystore(String keyStorePath) {
         Optional<String> keyStorePassword = getOptionalConfigProperty(KEYSTORE_PASSWORD, String.class);
         if (keyStorePassword.isPresent()) {

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtClaimsBuilderImpl.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtClaimsBuilderImpl.java
@@ -75,6 +75,10 @@ class JwtClaimsBuilderImpl extends JwtSignatureImpl implements JwtClaimsBuilder,
         super(fromMapToJwtClaims(claimsMap));
     }
 
+    JwtClaimsBuilderImpl(JwtClaims claims) {
+        super(claims);
+    }
+
     private static JwtClaims fromMapToJwtClaims(Map<String, Object> claimsMap) {
         JwtClaims claims = new JwtClaims();
         @SuppressWarnings("unchecked")

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtProviderImpl.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtProviderImpl.java
@@ -57,6 +57,14 @@ public class JwtProviderImpl extends JwtProvider {
      * {@inheritDoc}
      */
     @Override
+    public JwtClaimsBuilder claimsJson(String json) {
+        return new JwtClaimsBuilderImpl(JwtBuildUtils.parseJwtContent(json));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public JwtClaimsBuilder claims(JsonWebToken jwt) {
         Map<String, Object> claims = new LinkedHashMap<>();
         for (String name : jwt.getClaimNames()) {

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/spi/JwtProvider.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/spi/JwtProvider.java
@@ -98,6 +98,14 @@ public abstract class JwtProvider {
     public abstract JwtClaimsBuilder claims(String jsonLocation);
 
     /**
+     * Creates a new instance of {@link JwtClaimsBuilder} from a JSON string.
+     *
+     * @param json JSON string
+     * @return {@link JwtClaimsBuilder}
+     */
+    public abstract JwtClaimsBuilder claimsJson(String json);
+
+    /**
      * Creates a new instance of {@link JwtClaimsBuilder} from {@link JsonWebToken}.
      *
      * @param jwt JsonWebToken token.

--- a/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtEncryptTest.java
+++ b/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtEncryptTest.java
@@ -140,6 +140,21 @@ public class JwtEncryptTest {
     }
 
     @Test
+    void encryptJsonString() throws Exception {
+        String jweCompact = Jwt.claimsJson("{\"customClaim\":\"custom-value\"}")
+                .jwe().encrypt();
+
+        doTestEncryptedClaims(jweCompact);
+    }
+
+    @Test
+    void encryptJsonStringShortcut() throws Exception {
+        String jweCompact = Jwt.encryptJson("{\"customClaim\":\"custom-value\"}");
+
+        doTestEncryptedClaims(jweCompact);
+    }
+
+    @Test
     void encryptJsonObject() throws Exception {
         JsonObject json = Json.createObjectBuilder().add("customClaim", "custom-value").build();
         String jweCompact = Jwt.claims(json).jwe().encrypt();

--- a/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtSignEncryptTest.java
+++ b/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtSignEncryptTest.java
@@ -101,6 +101,20 @@ class JwtSignEncryptTest {
     }
 
     @Test
+    void innerSignAndEncryptJsonString() throws Exception {
+        String jweCompact = Jwt.claimsJson("{\"customClaim\":\"custom-value\"}")
+                .innerSign().encrypt();
+        checkRsaInnerSignedEncryptedClaims(jweCompact);
+    }
+
+    @Test
+    void innerSignAndEncryptJsonStringShortcut() throws Exception {
+        String jweCompact = Jwt.innerSignAndEncryptJson("{\"customClaim\":\"custom-value\"}");
+
+        checkRsaInnerSignedEncryptedClaims(jweCompact);
+    }
+
+    @Test
     void innerSignAndEncryptJsonObject() throws Exception {
         JsonObject json = Json.createObjectBuilder().add("customClaim", "custom-value").build();
         String jweCompact = Jwt.claims(json).innerSign().encrypt();

--- a/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtSignTest.java
+++ b/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtSignTest.java
@@ -274,6 +274,33 @@ class JwtSignTest {
     }
 
     @Test
+    void signJsonString() throws Exception {
+        String jwt = Jwt.claimsJson("{\"customClaim\":\"custom-value\"}")
+                .sign(getPrivateKey());
+
+        JsonWebSignature jws = getVerifiedJws(jwt);
+        JwtClaims claims = JwtClaims.parse(jws.getPayload());
+
+        assertEquals(4, claims.getClaimsMap().size());
+        checkDefaultClaimsAndHeaders(getJwsHeaders(jwt, 2), claims);
+
+        assertEquals("custom-value", claims.getClaimValue("customClaim"));
+    }
+
+    @Test
+    void signJsonStringShortcut() throws Exception {
+        String jwt = Jwt.signJson("{\"customClaim\":\"custom-value\"}");
+
+        JsonWebSignature jws = getVerifiedJws(jwt);
+        JwtClaims claims = JwtClaims.parse(jws.getPayload());
+
+        assertEquals(4, claims.getClaimsMap().size());
+        checkDefaultClaimsAndHeaders(getJwsHeaders(jwt, 2), claims);
+
+        assertEquals("custom-value", claims.getClaimValue("customClaim"));
+    }
+
+    @Test
     void signMapOfClaimsWithKeyLocation() throws Exception {
         String jwt = Jwt.claims(Collections.singletonMap("customClaim", "custom-value"))
                 .sign("/privateKey.pem");


### PR DESCRIPTION
Fixes #813.

This PR adds another method to the JWT builder API to simplify signing JSON strings.
For example, I've that often enough, in a test I have a JSON string ready (or it may be coming from DB) but we only have `Jwt.claims(Map)`, `Jwt.claims(JsonObject)` and `Jwt.claims(String jsonFileLocation)` start options - so I have to convert JSON String to JsonObject myself, which is not great.
 