### PR TITLE
Use JsonProvider holder

### DIFF
--- a/implementation/common/src/main/java/io/smallrye/jwt/JsonProviderHolder.java
+++ b/implementation/common/src/main/java/io/smallrye/jwt/JsonProviderHolder.java
@@ -1,0 +1,15 @@
+package io.smallrye.jwt;
+
+import jakarta.json.spi.JsonProvider;
+
+public final class JsonProviderHolder {
+
+    private static final JsonProvider JSON_PROVIDER = JsonProvider.provider();
+
+    private JsonProviderHolder() {
+    }
+
+    public static JsonProvider jsonProvider() {
+        return JSON_PROVIDER;
+    }
+}

--- a/implementation/common/src/main/java/io/smallrye/jwt/util/KeyUtils.java
+++ b/implementation/common/src/main/java/io/smallrye/jwt/util/KeyUtils.java
@@ -48,7 +48,6 @@ import java.util.Optional;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 
-import jakarta.json.Json;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonReader;
@@ -59,6 +58,7 @@ import org.jose4j.jwk.JsonWebKeySet;
 import org.jose4j.jwk.OctetSequenceJsonWebKey;
 import org.jose4j.jwk.PublicJsonWebKey;
 
+import io.smallrye.jwt.JsonProviderHolder;
 import io.smallrye.jwt.algorithm.KeyEncryptionAlgorithm;
 import io.smallrye.jwt.algorithm.SignatureAlgorithm;
 
@@ -452,7 +452,7 @@ public final class KeyUtils {
         JWTUtilLogging.log.loadingJwks();
 
         JsonObject jwks = null;
-        try (JsonReader reader = Json.createReader(new StringReader(content))) {
+        try (JsonReader reader = JsonProviderHolder.jsonProvider().createReader(new StringReader(content))) {
             jwks = reader.readObject();
         } catch (Exception ex) {
             JWTUtilLogging.log.loadingJwksFailed(ex);

--- a/implementation/jwt-auth/src/main/java/io/smallrye/jwt/JsonUtils.java
+++ b/implementation/jwt-auth/src/main/java/io/smallrye/jwt/JsonUtils.java
@@ -13,17 +13,14 @@ import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
 import jakarta.json.JsonString;
 import jakarta.json.JsonValue;
-import jakarta.json.spi.JsonProvider;
 
 public class JsonUtils {
-
-    private static final JsonProvider JSON_PROVIDER = JsonProvider.provider();
 
     private JsonUtils() {
     }
 
     public static JsonObject replaceMap(Map<String, Object> map) {
-        JsonObjectBuilder builder = JSON_PROVIDER.createObjectBuilder();
+        JsonObjectBuilder builder = JsonProviderHolder.jsonProvider().createObjectBuilder();
         for (Map.Entry<String, Object> entry : map.entrySet()) {
             Object entryValue = entry.getValue();
             if (entryValue instanceof Map) {
@@ -50,7 +47,7 @@ public class JsonUtils {
     }
 
     private static JsonArray toJsonArray(Collection<?> collection) {
-        JsonArrayBuilder arrayBuilder = JSON_PROVIDER.createArrayBuilder();
+        JsonArrayBuilder arrayBuilder = JsonProviderHolder.jsonProvider().createArrayBuilder();
 
         for (Object element : collection) {
             if (element instanceof String) {
@@ -73,11 +70,11 @@ public class JsonUtils {
             // This may already be a JsonValue
             jsonValue = (JsonValue) value;
         } else if (value instanceof String) {
-            jsonValue = JSON_PROVIDER.createValue(value.toString());
+            jsonValue = JsonProviderHolder.jsonProvider().createValue(value.toString());
         } else if ((value instanceof Long) || (value instanceof Integer)) {
-            jsonValue = JSON_PROVIDER.createValue(((Number) value).longValue());
+            jsonValue = JsonProviderHolder.jsonProvider().createValue(((Number) value).longValue());
         } else if (value instanceof Number) {
-            jsonValue = JSON_PROVIDER.createValue(((Number) value).doubleValue());
+            jsonValue = JsonProviderHolder.jsonProvider().createValue(((Number) value).doubleValue());
         } else if (value instanceof Boolean) {
             jsonValue = (Boolean) value ? JsonValue.TRUE : JsonValue.FALSE;
         } else if (value instanceof Collection) {


### PR DESCRIPTION
https://github.com/smallrye/smallrye-jwt/pull/836 removed JsonProvider instantiation from JsonUtils, but KeyUtils is still instantiating a new json provider every time that we load JWKs... this PR creates a JsonProviderHolder in the common lib, and reuses that in JsonUtils and KeyUtils so we remove all JsonProvider re-instantiation from the project.