### PR TITLE
Add claimTypeMismatch log message

### DIFF
--- a/implementation/jwt-auth/src/main/java/io/smallrye/jwt/auth/principal/DefaultJWTCallerPrincipal.java
+++ b/implementation/jwt-auth/src/main/java/io/smallrye/jwt/auth/principal/DefaultJWTCallerPrincipal.java
@@ -28,7 +28,8 @@ import org.jose4j.jwt.MalformedClaimException;
 import io.smallrye.jwt.JsonUtils;
 
 /**
- * A default implementation of JWTCallerPrincipal that wraps the jose4j JwtClaims.
+ * A default implementation of JWTCallerPrincipal that wraps the jose4j
+ * JwtClaims.
  *
  * @see JwtClaims
  */
@@ -36,7 +37,8 @@ public class DefaultJWTCallerPrincipal extends JWTCallerPrincipal {
     private final JwtClaims claimsSet;
 
     /**
-     * Create the DefaultJWTCallerPrincipal from the parsed JWT token and the extracted principal name
+     * Create the DefaultJWTCallerPrincipal from the parsed JWT token and the
+     * extracted principal name
      *
      * @param rawToken - raw token value
      * @param tokenType - token type
@@ -115,7 +117,9 @@ public class DefaultJWTCallerPrincipal extends JWTCallerPrincipal {
                         claim = 0L;
                     }
                 } catch (MalformedClaimException e) {
-                    PrincipalLogging.log.getGroupsFailure(claimName, e);
+                    Object value = claimsSet.getClaimValue(claimType.name());
+                    PrincipalLogging.log.claimTypeMismatch(claimName, claimType.getType().getSimpleName(),
+                            value.getClass().getSimpleName());
                 }
                 break;
             case groups:

--- a/implementation/jwt-auth/src/main/java/io/smallrye/jwt/auth/principal/PrincipalLogging.java
+++ b/implementation/jwt-auth/src/main/java/io/smallrye/jwt/auth/principal/PrincipalLogging.java
@@ -193,4 +193,8 @@ interface PrincipalLogging extends BasicLogger {
     @Message(id = 8044, value = "Encrypted token headers must contain a content type header")
     void encryptedTokenMissingContentType();
 
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 8045, value = "Claim %s's value type is expected to be %s but it is %s")
+    void claimTypeMismatch(String claimName, String expectedType, String actualType);
+
 }


### PR DESCRIPTION
When a numerical claim such as `updated_at` is presented as String by a provider like Auth0 (see https://github.com/quarkusio/quarkus/issues/43924), `smallrye-jwt` issues a warning, which is fair enough, since this and other standard claims are expected to be numbers, see the [OIDC spec](https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims), and MP JWT spec itself expects such claims be numbers (long), for example, [Claims.updated_at](https://github.com/eclipse/microprofile-jwt-auth/blob/main/api/src/main/java/org/eclipse/microprofile/jwt/Claims.java#L51).

What is a bit of a problem is that in https://github.com/quarkusio/quarkus/issues/43924 it happens during the implicit overridden toString() call and getting this warning is confusing given that probably noone is ever trying to check the `updated_at` claim...

So in this PR I simply made it log a more informative message at debug level... 

The problem in general now is that if someone does want to get such claim as String, while it is specified to be of type `long`, then `JsonWebToken` API can't help directly... Now, there is a method `Object getClaim(String)` and I was thinking, I just get that String returned instead of long, but I'm nearly sure it will get me into a lot of trouble :-)

So if some OIDC providers ignore the specification advice and issue claims which are supposed to be numbers as strings, then smallrye-jwt users can still get the raw token with `getClaim(Claims.raw_token)` and extracting such claim using JsonObject.  