### PR TITLE
Make it possible to disable adding default claims

### DIFF
--- a/doc/modules/ROOT/pages/generate-jwt.adoc
+++ b/doc/modules/ROOT/pages/generate-jwt.adoc
@@ -154,6 +154,7 @@ Smallrye JWT supports the following properties which can be used to customize th
 |smallrye.jwt.new-token.issuer|none|Token issuer which can be used to set an `iss` (issuer) claim value if this claim has not already been set.
 |smallrye.jwt.new-token.audience|none|Token audience which can be used to set an `aud` (audience) claim value if this claim has not already been set.
 |smallrye.jwt.new-token.override-matching-claims|false|Override the existing `iss` or `aud` claim values if `smallrye.jwt.new-token.issuer` or `smallrye.jwt.new-token.audience` properties are set.
+|smallrye.jwt.new-token.add-default-claims|true|Disable an automatic addition of the `iat` (issued at), `exp` (expiration time) and `jti` (token identifier) claims when such claims have not already been set.
 |smallrye.jwt.keystore.type|`JKS`|This property can be used to customize a keystore type if either `smallrye.jwt.sign.key.location` or `smallrye.jwt.encrypt.key.location` or both of these properties point to a `KeyStore` file. If it is not set then the file name will be checked to determine the keystore type before defaulting to `JKS`.
 |smallrye.jwt.keystore.provider||This property can be used to customize a `KeyStore` provider if `smallrye.jwt.sign.key.location` or `smallrye.jwt.encrypt.key.location` point to a `KeyStore` file.
 |smallrye.jwt.keystore.password||Keystore password. If `smallrye.jwt.sign.key.location` or `smallrye.jwt.encrypt.key.location` point to a `KeyStore` file then this property has be set.

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/JwtClaimsBuilder.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/JwtClaimsBuilder.java
@@ -17,7 +17,8 @@ import org.eclipse.microprofile.jwt.Claims;
  *
  * <p>
  * JwtClaimsBuilder implementations must set the 'iat' (issued at time), 'exp' (expiration time)
- * and 'jti' (unique token identifier) claims unless they have already been set.
+ * and 'jti' (unique token identifier) claims unless they have already been set
+ * or the 'smallrye.jwt.new-token.add-default-claims' property is set to "false".
  * JwtClaimsBuilder must ensure a 'jti' claim value is unique when the same builder is used for building more than one token.
  * <p>
  * By default the 'iat' claim is set to the current time in seconds and the 'exp' claim is set by adding a default token

--- a/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtBuildUtils.java
+++ b/implementation/jwt-build/src/main/java/io/smallrye/jwt/build/impl/JwtBuildUtils.java
@@ -32,6 +32,7 @@ public class JwtBuildUtils {
     public static final String NEW_TOKEN_ISSUER_PROPERTY = "smallrye.jwt.new-token.issuer";
     public static final String NEW_TOKEN_AUDIENCE_PROPERTY = "smallrye.jwt.new-token.audience";
     public static final String NEW_TOKEN_OVERRIDE_CLAIMS_PROPERTY = "smallrye.jwt.new-token.override-matching-claims";
+    public static final String NEW_TOKEN_ADD_DEFAULT_CLAIMS_PROPERTY = "smallrye.jwt.new-token.add-default-claims";
     public static final String NEW_TOKEN_LIFESPAN_PROPERTY = "smallrye.jwt.new-token.lifespan";
     public static final String NEW_TOKEN_SIGNATURE_ALG_PROPERTY = "smallrye.jwt.new-token.signature-algorithm";
     public static final String NEW_TOKEN_KEY_ENCRYPTION_ALG_PROPERTY = "smallrye.jwt.new-token.key-encryption-algorithm";
@@ -51,13 +52,18 @@ public class JwtBuildUtils {
 
     static void setDefaultJwtClaims(JwtClaims claims, Long tokenLifespan) {
 
-        if (!claims.hasClaim(Claims.iat.name())) {
-            claims.setIssuedAt(NumericDate.fromSeconds(currentTimeInSecs()));
-        }
-        setExpiryClaim(claims, tokenLifespan);
+        Boolean addDefaultClaims = getConfigProperty(JwtBuildUtils.NEW_TOKEN_ADD_DEFAULT_CLAIMS_PROPERTY, Boolean.class,
+                Boolean.TRUE);
 
-        if (!claims.hasClaim(Claims.jti.name())) {
-            claims.setClaim(Claims.jti.name(), UUID.randomUUID().toString());
+        if (addDefaultClaims) {
+            if (!claims.hasClaim(Claims.iat.name())) {
+                claims.setIssuedAt(NumericDate.fromSeconds(currentTimeInSecs()));
+            }
+            setExpiryClaim(claims, tokenLifespan);
+
+            if (!claims.hasClaim(Claims.jti.name())) {
+                claims.setClaim(Claims.jti.name(), UUID.randomUUID().toString());
+            }
         }
 
         Boolean overrideMatchingClaims = getConfigProperty(NEW_TOKEN_OVERRIDE_CLAIMS_PROPERTY, Boolean.class);

--- a/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtBuildConfigSource.java
+++ b/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtBuildConfigSource.java
@@ -22,6 +22,7 @@ public class JwtBuildConfigSource implements ConfigSource {
             JwtBuildUtils.NEW_TOKEN_AUDIENCE_PROPERTY,
             JwtBuildUtils.NEW_TOKEN_LIFESPAN_PROPERTY,
             JwtBuildUtils.NEW_TOKEN_OVERRIDE_CLAIMS_PROPERTY,
+            JwtBuildUtils.NEW_TOKEN_ADD_DEFAULT_CLAIMS_PROPERTY,
             JwtBuildUtils.NEW_TOKEN_SIGNATURE_ALG_PROPERTY,
             JwtBuildUtils.NEW_TOKEN_KEY_ENCRYPTION_ALG_PROPERTY,
             JwtBuildUtils.SIGN_KEYSTORE_KEY_ALIAS,
@@ -49,6 +50,7 @@ public class JwtBuildConfigSource implements ConfigSource {
 
     private boolean relaxSignatureKeyValidation;
     private boolean relaxEncryptionKeyValidation;
+    private boolean addDefaultClaims = true;
 
     @Override
     public Map<String, String> getProperties() {
@@ -116,6 +118,8 @@ public class JwtBuildConfigSource implements ConfigSource {
             map.put(JwtBuildUtils.ENC_KEY_RELAX_VALIDATION_PROPERTY, String.valueOf(relaxEncryptionKeyValidation));
         }
 
+        map.put(JwtBuildUtils.NEW_TOKEN_ADD_DEFAULT_CLAIMS_PROPERTY, String.valueOf(addDefaultClaims));
+
         map.put(JwtBuildUtils.NEW_TOKEN_OVERRIDE_CLAIMS_PROPERTY, String.valueOf(overrideMatchingClaims));
         return map;
     }
@@ -177,6 +181,10 @@ public class JwtBuildConfigSource implements ConfigSource {
 
     public void setOverrideMatchingClaims(boolean override) {
         overrideMatchingClaims = override;
+    }
+
+    public void setAddDefaultClaims(boolean add) {
+        addDefaultClaims = add;
     }
 
     public void resetSigningKeyCallCount() {

--- a/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtSignTest.java
+++ b/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtSignTest.java
@@ -387,6 +387,31 @@ class JwtSignTest {
     }
 
     @Test
+    void signWithoutAddingDefaultClaim() throws Exception {
+        KeyPair keyPair = KeyUtils.generateKeyPair(2048);
+
+        JwtBuildConfigSource configSource = getConfigSource();
+        configSource.setAddDefaultClaims(false);
+        try {
+            String jwt = Jwt.claims(Collections.singletonMap("customClaim", "custom-value"))
+                    .sign(keyPair.getPrivate());
+
+            JsonWebSignature jws = getVerifiedJws(jwt, keyPair.getPublic(), true);
+            JwtClaims claims = JwtClaims.parse(jws.getPayload());
+
+            assertEquals(1, claims.getClaimsMap().size());
+            assertEquals("custom-value", claims.getClaimValue("customClaim"));
+
+            Map<String, Object> headers = getJwsHeaders(jwt, 2);
+            assertEquals("RS256", headers.get("alg"));
+            assertEquals("JWT", headers.get("typ"));
+
+        } finally {
+            configSource.setAddDefaultClaims(true);
+        }
+    }
+
+    @Test
     void signClaimsConfiguredKeyLocation() throws Exception {
         JwtBuildConfigSource configSource = getConfigSource();
         try {


### PR DESCRIPTION
Fixes #858

The issued at (`iat`), expiration time (`exp`) and `jti` claims are currently set by default if they have not already been set, but some token consumers are too sensitive to the presence of extra claims they don't process (even though, once the signature has been verified, the content is secure).

So I've added a property to make it possible to disable the addition of the default properties