### PR TITLE
Fix split package issue

### DIFF
--- a/implementation/common/src/main/java/io/smallrye/jwt/common/JsonProviderHolder.java
+++ b/implementation/common/src/main/java/io/smallrye/jwt/common/JsonProviderHolder.java
@@ -1,4 +1,4 @@
-package io.smallrye.jwt;
+package io.smallrye.jwt.common;
 
 import jakarta.json.spi.JsonProvider;
 

--- a/implementation/common/src/main/java/io/smallrye/jwt/util/KeyUtils.java
+++ b/implementation/common/src/main/java/io/smallrye/jwt/util/KeyUtils.java
@@ -58,9 +58,9 @@ import org.jose4j.jwk.JsonWebKeySet;
 import org.jose4j.jwk.OctetSequenceJsonWebKey;
 import org.jose4j.jwk.PublicJsonWebKey;
 
-import io.smallrye.jwt.JsonProviderHolder;
 import io.smallrye.jwt.algorithm.KeyEncryptionAlgorithm;
 import io.smallrye.jwt.algorithm.SignatureAlgorithm;
+import io.smallrye.jwt.common.JsonProviderHolder;
 
 /**
  * Utility methods for dealing with decoding public and private keys resources

--- a/implementation/jwt-auth/src/main/java/io/smallrye/jwt/JsonUtils.java
+++ b/implementation/jwt-auth/src/main/java/io/smallrye/jwt/JsonUtils.java
@@ -14,6 +14,8 @@ import jakarta.json.JsonObjectBuilder;
 import jakarta.json.JsonString;
 import jakarta.json.JsonValue;
 
+import io.smallrye.jwt.common.JsonProviderHolder;
+
 public class JsonUtils {
 
     private JsonUtils() {


### PR DESCRIPTION
Fixes #885 

Creates common package (it is the common artifact) moves JsonProviderHolder to it fixing the split package situation where we have the same package in the common and jwt-auth projects.