### PR TITLE
Convert key and content encryption algorithms to upper case

### DIFF
--- a/implementation/common/src/main/java/io/smallrye/jwt/algorithm/ContentEncryptionAlgorithm.java
+++ b/implementation/common/src/main/java/io/smallrye/jwt/algorithm/ContentEncryptionAlgorithm.java
@@ -24,6 +24,6 @@ public enum ContentEncryptionAlgorithm {
     }
 
     public static ContentEncryptionAlgorithm fromAlgorithm(String algorithmName) {
-        return ContentEncryptionAlgorithm.valueOf(algorithmName.replaceAll("-", "_").replaceAll("\\+", "_"));
+        return ContentEncryptionAlgorithm.valueOf(algorithmName.replaceAll("-", "_").replaceAll("\\+", "_").toUpperCase());
     }
 }

--- a/implementation/common/src/main/java/io/smallrye/jwt/algorithm/KeyEncryptionAlgorithm.java
+++ b/implementation/common/src/main/java/io/smallrye/jwt/algorithm/KeyEncryptionAlgorithm.java
@@ -34,7 +34,7 @@ public enum KeyEncryptionAlgorithm {
     }
 
     public static KeyEncryptionAlgorithm fromAlgorithm(String algorithmName) {
-        return KeyEncryptionAlgorithm.valueOf(algorithmName.replaceAll("-", "_").replaceAll("\\+", "_"));
+        return KeyEncryptionAlgorithm.valueOf(algorithmName.replaceAll("-", "_").replaceAll("\\+", "_").toUpperCase());
     }
 
 }

--- a/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtEncryptTest.java
+++ b/implementation/jwt-build/src/test/java/io/smallrye/jwt/build/JwtEncryptTest.java
@@ -499,6 +499,24 @@ public class JwtEncryptTest {
     }
 
     @Test
+    void encryptWithSecretKeyAndUseDirAlgoJwk() throws Exception {
+        String jweCompact = Jwt.claims()
+                .claim("customClaim", "custom-value")
+                .jwe()
+                .keyId("key-enc-key-id")
+                .keyAlgorithm(KeyEncryptionAlgorithm.DIR)
+                .encrypt("secretKey.jwk");
+
+        checkJweHeaders(jweCompact, "dir", 3);
+
+        Key secretKey = KeyUtils.readEncryptionKey("/secretKey.jwk", null, null);
+        JsonWebEncryption jwe = getJsonWebEncryption(jweCompact, secretKey);
+
+        JwtClaims claims = JwtClaims.parse(jwe.getPlaintextString());
+        checkJwtClaims(claims);
+    }
+
+    @Test
     void encryptWithSecretPassword() throws Exception {
         String secret = "AyM1SysPpbyDfgZld3umj1qzKObwVMko";
 

--- a/implementation/jwt-build/src/test/resources/secretKey.jwk
+++ b/implementation/jwt-build/src/test/resources/secretKey.jwk
@@ -1,0 +1,5 @@
+{
+  "kty":"oct",
+  "k":"GawgguFyGrWKav7AX4VKUgK_mT2YH2W1R9L5Zz8XkB4",
+  "kid": "key-enc-key-id"
+}


### PR DESCRIPTION
Fixes #887

It is already done for the signature algorithms